### PR TITLE
fix: tidy up package.json, add pre-commit hook for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ docker exec postgres psql -U postgres -f /tmp/examples/create_tables.example.sql
 
 ```
 npm i
-npm run start-dev
+npm run dev
 ```
 
 Go to http://localhost:8000/graphiql for an interactive query brower.

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "events": {
+    "restart": "npm run format"
+  }
+}

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,0 @@
-{
-  "events": {
-    "restart": "npm run format"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/aerogear/aerogear-data-sync-server#readme",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint && echo 'need to add tests'",
+    "test": "echo 'need to add tests'",
     "start": "node ./server.js",
     "dev": "SCHEMA_FILE=./examples/schema.example.graphql DATA_SOURCES_FILE=./examples/data-sources.example.json RESOLVER_MAPPINGS_FILE=./examples/resolver-mappings.example.json QUERY_FILE=./examples/query.example.graphql nodemon ./server.js",
     "lint": "standard",
@@ -44,6 +44,7 @@
     "subscriptions-transport-ws": "^0.9.11"
   },
   "pre-commit": [
+    "lint",
     "test"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,6 @@
   "name": "data-sync-server",
   "version": "1.0.0",
   "description": "GraphQL based server for syncing data between clients",
-  "main": "index.js",
-  "scripts": {
-    "test": "standard --fix && mocha",
-    "start": "node ./server.js",
-    "start-dev": "SCHEMA_FILE=./examples/schema.example.graphql DATA_SOURCES_FILE=./examples/data-sources.example.json RESOLVER_MAPPINGS_FILE=./examples/resolver-mappings.example.json QUERY_FILE=./examples/query.example.graphql nodemon ./server.js",
-    "format": "standard --fix"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aerogear/aerogear-data-sync-server.git"
@@ -24,8 +17,17 @@
     "url": "https://github.com/aerogear/aerogear-data-sync-server/issues"
   },
   "homepage": "https://github.com/aerogear/aerogear-data-sync-server#readme",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run lint && echo 'need to add tests'",
+    "start": "node ./server.js",
+    "dev": "SCHEMA_FILE=./examples/schema.example.graphql DATA_SOURCES_FILE=./examples/data-sources.example.json RESOLVER_MAPPINGS_FILE=./examples/resolver-mappings.example.json QUERY_FILE=./examples/query.example.graphql nodemon ./server.js",
+    "lint": "standard",
+    "format": "standard --fix"
+  },
   "devDependencies": {
     "nodemon": "^1.17.5",
+    "pre-commit": "^1.2.2",
     "standard": "^11.0.1"
   },
   "dependencies": {
@@ -40,5 +42,8 @@
     "lodash": "^4.17.10",
     "pg": "^7.4.3",
     "subscriptions-transport-ws": "^0.9.11"
-  }
+  },
+  "pre-commit": [
+    "test"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GraphQL based server for syncing data between clients",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aerogear/aerogear-data-sync-server.git"
+    "url": "git+https://github.com/aerogear/data-sync-server.git"
   },
   "keywords": [
     "graphql",
@@ -14,9 +14,9 @@
   "author": "davmarti@redhat.com",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/aerogear/aerogear-data-sync-server/issues"
+    "url": "https://github.com/aerogear/data-sync-server/issues"
   },
-  "homepage": "https://github.com/aerogear/aerogear-data-sync-server#readme",
+  "homepage": "https://github.com/aerogear/data-sync-server#readme",
   "main": "index.js",
   "scripts": {
     "test": "echo 'need to add tests'",


### PR DESCRIPTION
This PR makes some very small, developer friendly changes,

* reorders some bits in package.json
* changes some of the npm commands
* puts a placeholder test command
* removes the nodemon.json config that tries to auto lint. This regularly causes crashes which is pretty bad from a developer experience perspective
* adds a precommit hook which runs tests - we can keep this pretty lightweight by running integration tests in a different command. (If we need)

Ping @aliok @david-martin 