### PR TITLE
feat: initial CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ version: 2
       steps:
         - checkout
         - setup_remote_docker
+        - run: npm run release:validate
         - run: npm run docker:build:release
         - run: npm run docker:push:release
 
@@ -50,6 +51,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /\d\.\d\.\d/
+              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ version: 2
         - image: circleci/node:carbon
       steps:
         - checkout
+        - setup_remote_docker
         - run: npm run docker:build
         - run: npm run docker:push
 
@@ -25,22 +26,30 @@ version: 2
         - image: circleci/node:carbon
       steps:
         - checkout
+        - setup_remote_docker
         - run: npm run docker:build:release
         - run: npm run docker:push:release
 
 workflows:
   version: 2
-  build_and_release:
+  build_and_push:
     jobs:
-      - build:
+      - test:
           filters:
             tags:
               only: /.*/
-      - npm_publish:
+      - docker_push_master:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - docker_push_release:
           requires:
             - build
           filters:
             tags:
-              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
+              only: /\d\.\d\.\d/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2
+  jobs:
+    test:
+      docker:
+        # Node 8 LTS
+        - image: circleci/node:carbon
+      steps:
+        - checkout
+        - run: npm install
+        - run: npm run lint
+        - run: npm test
+
+    docker_push_master:
+      docker:
+        # Node 8 LTS
+        - image: circleci/node:carbon
+      steps:
+        - checkout
+        - run: npm run docker:build
+        - run: npm run docker:push
+
+    docker_push_release:
+      docker:
+        # Node 8 LTS
+        - image: circleci/node:carbon
+      steps:
+        - checkout
+        - run: npm run docker:build:release
+        - run: npm run docker:push:release
+
+workflows:
+  version: 2
+  build_and_release:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - npm_publish:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,14 @@ workflows:
               only: /.*/
       - docker_push_master:
           requires:
-            - build
+            - test
           filters:
             branches:
               only:
                 - master
       - docker_push_release:
           requires:
-            - build
+            - test
           filters:
             tags:
               only: /\d\.\d\.\d/


### PR DESCRIPTION
Adds a CircleCI config that will allow docker release stuff.

The actual docker commands should be implemented in a separate PR

@david-martin I have two suggestions for the docker build commands.

Either implement them directly in `package.json` or create a `scripts` directory with the appropriate bash scripts that perform the right commands, then wire up the commands in `package.json` to the scripts