### PR TITLE
refactor: simplify dataSourceParser and resolverMaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,30 @@ The baseline architecture is shown below:
 6. Configured Authentication & Autohorizatin checks are applied
 7. Logging & Metrics data is gathered from the Server & connected Clients
 
+## Running Tests
+
+```
+npm run test
+```
+
+### Debugging Individual Tests
+
+The easiest way to debug tests is using Chrome DevTools. Use [inspect-process](https://npm.im/inspect-process) to easily launch a debugging session with Chrome DevTools.
+
+```
+npm install -g inspect-process
+```
+
+* In chrome go to [`chrome://inspect`](chrome://inspect/)
+* Click on 'Open dedicated DevTools for Node.' This will open a new DevTools window.
+* Click on 'add folder to workspace' and use the wizard to open this project.
+* Go to the appropriate test file (or code that's being tested) and set a breakpoint
+* Now run the individual test as follows:
+
+```
+inspect node_modules/ava/profile.js some/test/file.js
+```
+
+The DevTools window should automatically connect to the debugging session and execution should pause if some breakpoints are set.
+
+

--- a/examples/resolver-mappings.example.json
+++ b/examples/resolver-mappings.example.json
@@ -1,31 +1,32 @@
 {
-  "Query": {
-    "readNote": {
-      "dataSource": "p1",
-      "requestMapping": "SELECT id, title, content, timestamp FROM \"Notes\" WHERE id='{{context.arguments.id}}';",
-      "responseMapping": "{{toJSON context.result.[0]}}"
-    },
-    "listNotes": {
-      "dataSource": "p1",
-      "requestMapping": "SELECT id, title, content, timestamp FROM \"Notes\"",
-      "responseMapping": "{{toJSON context.result}}"
-    }
+  "readNote": {
+    "type": "Query",
+    "dataSource": "p1",
+    "requestMapping": "SELECT id, title, content, timestamp FROM \"Notes\" WHERE id='{{context.arguments.id}}';",
+    "responseMapping": "{{toJSON context.result.[0]}}"
   },
-  "Mutation": {
-    "createNote": {
-      "dataSource": "p1",
-      "requestMapping": "INSERT INTO \"Notes\" (\"id\",\"title\",\"content\",\"timestamp\") VALUES ('{{context.arguments.id}}','{{context.arguments.title}}','{{context.arguments.content}}',{{context.arguments.timestamp}}) RETURNING *;",
-      "responseMapping": "{{toJSON context.result.[0]}}"
-    },
-    "updateNote": {
-      "dataSource": "p1",
-      "requestMapping": "UPDATE \"Notes\" SET \"title\"='{{context.arguments.title}}',\"content\"='{{context.arguments.content}}' WHERE \"id\"='{{context.arguments.id}}' RETURNING *",
-      "responseMapping": "{{toJSON context.result.[0]}}"
-    },
-    "deleteNote": {
-      "dataSource": "p1",
-      "requestMapping": "DELETE FROM \"Notes\" WHERE \"id\"='{{context.arguments.id}}' RETURNING *",
-      "responseMapping": "{{toJSON context.result.[0]}}"
-    }
+  "listNotes": {
+    "type": "Query",
+    "dataSource": "p1",
+    "requestMapping": "SELECT id, title, content, timestamp FROM \"Notes\"",
+    "responseMapping": "{{toJSON context.result}}"
+  },
+  "createNote": {
+    "type": "Mutation",
+    "dataSource": "p1",
+    "requestMapping": "INSERT INTO \"Notes\" (\"id\",\"title\",\"content\",\"timestamp\") VALUES ('{{context.arguments.id}}','{{context.arguments.title}}','{{context.arguments.content}}',{{context.arguments.timestamp}}) RETURNING *;",
+    "responseMapping": "{{toJSON context.result.[0]}}"
+  },
+  "updateNote": {
+    "type": "Mutation",
+    "dataSource": "p1",
+    "requestMapping": "UPDATE \"Notes\" SET \"title\"='{{context.arguments.title}}',\"content\"='{{context.arguments.content}}' WHERE \"id\"='{{context.arguments.id}}' RETURNING *",
+    "responseMapping": "{{toJSON context.result.[0]}}"
+  },
+  "deleteNote": {
+    "type": "Mutation",
+    "dataSource": "p1",
+    "requestMapping": "DELETE FROM \"Notes\" WHERE \"id\"='{{context.arguments.id}}' RETURNING *",
+    "responseMapping": "{{toJSON context.result.[0]}}"
   }
 }

--- a/server/lib/dataSourceParser.js
+++ b/server/lib/dataSourceParser.js
@@ -1,30 +1,29 @@
 const _ = require('lodash')
-const {Client} = require('pg')
+const { Client } = require('pg')
 
-module.exports = function (dataSources, connect = true) {
-  let dataSourceClients = {}
-  let dataSourceTypes = {}
+module.exports = function (dataSourceDefs, connect = true) {
+  let dataSources = {}
   // connect to any datasources with persistent connections
-  _.forEach(dataSources, (value, key) => {
+  _.forEach(dataSourceDefs, (dataSource, dataSourceName) => {
     let isHandled = false
-    if (value.type === 'postgres') {
-      dataSourceClients[key] = new Client(value.config)
-      if (connect) {
-        dataSourceClients[key].connect()
-      }
+
+    if (dataSource.type === 'postgres') {
+      dataSources[dataSourceName] = createPostgresDataSource(dataSource.config, connect)
       isHandled = true
     }
 
-    if (isHandled) {
-      dataSourceTypes[key] = value.type
-    } else {
-      throw new Error('Unhandled data source type: ' + value.type)
+    if (!isHandled) {
+      throw new Error('Unhandled data source type: ' + dataSource.type)
     }
   })
 
-  return {
-    dataSourceTypes,
-    // didn't want to set 'type' property on pg.Client object
-    dataSourceClients
+  return dataSources
+}
+
+function createPostgresDataSource (config, connect = true) {
+  let client = new Client(config)
+  if (connect) {
+    client.connect()
   }
+  return { client, type: 'postgres' }
 }

--- a/server/lib/dataSourceParser.test.js
+++ b/server/lib/dataSourceParser.test.js
@@ -3,7 +3,7 @@ const {test} = require('ava')
 const dataSourceParser = require('./dataSourceParser')
 
 test('should parse single data source successfully', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -15,15 +15,18 @@ test('should parse single data source successfully', t => {
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false)
+  const dataSources = dataSourceParser(dataSourceDefs, false)
 
-  t.deepEqual(dataSourceTypes, {'p1': 'postgres'})
-  t.is(Object.keys(dataSourceClients).length, 1)
-  t.truthy(dataSourceClients['p1'])
+  t.is(Object.keys(dataSources).length, 1)
+  t.truthy(dataSources['p1'])
+
+  let { type, client } = dataSources['p1']
+  t.deepEqual(type, 'postgres')
+  t.truthy(client)
 })
 
 test('should parse multiple data sources successfully', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -45,22 +48,20 @@ test('should parse multiple data sources successfully', t => {
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false)
+  const dataSources = dataSourceParser(dataSourceDefs, false)
 
-  t.is(Object.keys(dataSourceTypes).length, 2)
-  t.is(Object.keys(dataSourceClients).length, 2)
+  t.is(Object.keys(dataSources).length, 2)
 })
 
 test('should return empty results when no data source is defined', t => {
-  const dataSources = {}
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false)
+  const dataSourceDefs = {}
+  const dataSources = dataSourceParser(dataSourceDefs, false)
 
-  t.deepEqual(dataSourceTypes, {})
-  t.deepEqual(dataSourceClients, {})
+  t.deepEqual(dataSources, {})
 })
 
 test('should throw error when there is an unknown data source', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'foo',
       'config': {
@@ -70,6 +71,6 @@ test('should throw error when there is an unknown data source', t => {
   }
 
   t.throws(() => {
-    dataSourceParser(dataSources, false)
+    dataSourceParser(dataSourceDefs, false)
   })
 })

--- a/server/lib/resolverMaker.js
+++ b/server/lib/resolverMaker.js
@@ -32,20 +32,18 @@ module.exports = function (dataSources, resolverMappings) {
       throw new Error('Unknown data source "' + resolverMapping.dataSource + '" for mapping ' + resolverMappingName)
     }
 
-    if (['Query', 'Mutation'].indexOf(resolverMapping.type) < 0) {
-      return
-    }
-
     let { type, client } = dataSources[resolverMapping.dataSource]
 
     if (type === 'postgres') {
       try {
+        resolvers[resolverMapping.type] = resolvers[resolverMapping.type] || {} // temporary hack. This will be refactored as part of AEROGEAR-3436
         resolvers[resolverMapping.type][resolverMappingName] = buildPostgresResolver(
           client,
           resolverMapping.requestMapping,
           resolverMapping.responseMapping
         )
       } catch (ex) {
+        console.log(ex)
         console.log('Error while building Postgres resolver for mapping: ' + resolverMappingName)
         throw new Error('Error while building Postgres resolver for mapping: ' + resolverMappingName)
       }

--- a/server/lib/resolverMaker.js
+++ b/server/lib/resolverMaker.js
@@ -32,6 +32,10 @@ module.exports = function (dataSources, resolverMappings) {
       throw new Error('Unknown data source "' + resolverMapping.dataSource + '" for mapping ' + resolverMappingName)
     }
 
+    if (['Query', 'Mutation'].indexOf(resolverMapping.type) < 0) {
+      return
+    }
+
     let { type, client } = dataSources[resolverMapping.dataSource]
 
     if (type === 'postgres') {

--- a/server/lib/resolverMaker.js
+++ b/server/lib/resolverMaker.js
@@ -4,50 +4,48 @@ Handlebars.registerHelper('toJSON', function (json) {
   return new Handlebars.SafeString(JSON.stringify(json))
 })
 
-module.exports = function (dataSourceTypes, dataSourceClients, resolverMappingsJson) {
+module.exports = function (dataSources, resolverMappings) {
   const resolvers = {
     Query: {},
     Mutation: {},
     Subscription: {}
   }
 
-  _.forEach(resolverMappingsJson, (resolverMapping, resolverMappingName) => {
-    // only setup mappings for queries and mutations at this time
-    if (['Query', 'Mutation'].indexOf(resolverMappingName) < 0) {
-      return
+  _.forEach(resolverMappings, (resolverMapping, resolverMappingName) => {
+    if (_.isEmpty(resolverMapping.type)) {
+      throw new Error('Missing query type for mapping: ' + resolverMappingName)
     }
 
-    _.forEach(resolverMapping, (value, key) => {
-      if (_.isEmpty(value.dataSource)) {
-        throw new Error('Missing data source for mapping: ' + key)
-      }
+    if (_.isEmpty(resolverMapping.dataSource)) {
+      throw new Error('Missing data source for mapping: ' + resolverMappingName)
+    }
 
-      if (_.isEmpty(value.requestMapping)) {
-        throw new Error('Missing request mapping for mapping: ' + key)
-      }
+    if (_.isEmpty(resolverMapping.requestMapping)) {
+      throw new Error('Missing request mapping for mapping: ' + resolverMappingName)
+    }
 
-      if (_.isEmpty(value.responseMapping)) {
-        throw new Error('Missing response mapping for mapping: ' + key)
-      }
+    if (_.isEmpty(resolverMapping.responseMapping)) {
+      throw new Error('Missing response mapping for mapping: ' + resolverMappingName)
+    }
 
-      if (!(value.dataSource in dataSourceTypes)) {
-        throw new Error('Unknown data source "' + value.dataSource + '" for mapping ' + key)
-      }
+    if (!(resolverMapping.dataSource in dataSources)) {
+      throw new Error('Unknown data source "' + resolverMapping.dataSource + '" for mapping ' + resolverMappingName)
+    }
 
-      if (dataSourceTypes[value.dataSource] === 'postgres') {
-        const dataSourceClient = dataSourceClients[value.dataSource]
-        try {
-          resolvers[resolverMappingName][key] = buildPostgresResolver(
-            dataSourceClient,
-            value.requestMapping,
-            value.responseMapping
-          )
-        } catch (ex) {
-          console.log('Error while building Postgres resolver for mapping: ' + key)
-          throw new Error('Error while building Postgres resolver for mapping: ' + key)
-        }
+    let { type, client } = dataSources[resolverMapping.dataSource]
+
+    if (type === 'postgres') {
+      try {
+        resolvers[resolverMapping.type][resolverMappingName] = buildPostgresResolver(
+          client,
+          resolverMapping.requestMapping,
+          resolverMapping.responseMapping
+        )
+      } catch (ex) {
+        console.log('Error while building Postgres resolver for mapping: ' + resolverMappingName)
+        throw new Error('Error while building Postgres resolver for mapping: ' + resolverMappingName)
       }
-    })
+    }
   })
 
   return resolvers

--- a/server/lib/resolverMaker.test.js
+++ b/server/lib/resolverMaker.test.js
@@ -55,7 +55,7 @@ test('should return empty when feeded empty', t => {
   })
 })
 
-test('should ignore unknown operations', t => {
+test('should allow unknown operations', t => {
   const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
@@ -82,7 +82,7 @@ test('should ignore unknown operations', t => {
   }
   const resolvers = resolverMaker(dataSources, resolverMappings)
 
-  t.deepEqual(Object.keys(resolvers), ['Query', 'Mutation', 'Subscription'])
+  t.deepEqual(Object.keys(resolvers), ['Query', 'Mutation', 'Subscription', 'UnknownOperation'])
 
   t.deepEqual(Object.keys(resolvers.Query), ['q1'])
   t.deepEqual(Object.keys(resolvers.Mutation), [])

--- a/server/lib/resolverMaker.test.js
+++ b/server/lib/resolverMaker.test.js
@@ -11,7 +11,7 @@ const resolverMaker = require('./resolverMaker')
  */
 
 test('should create Postgres resolvers successfully with no Handlebars templates', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -19,25 +19,24 @@ test('should create Postgres resolvers successfully with no Handlebars templates
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
 
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': 'q1_requestMapping {{ var }}',
-        'responseMapping': 'q1_responseMapping {{ toJSON "foo" }}'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': 'q1_requestMapping {{ var }}',
+      'responseMapping': 'q1_responseMapping {{ toJSON "foo" }}'
     },
-    'Mutation': {
-      'm1': {
-        'dataSource': 'p1',
-        'requestMapping': 'm1_requestMapping  {{ var }}',
-        'responseMapping': 'm1_responseMapping {{ toJSON "foo" }}'
-      }
+    'm1': {
+      'type': 'Mutation',
+      'dataSource': 'p1',
+      'requestMapping': 'm1_requestMapping  {{ var }}',
+      'responseMapping': 'm1_responseMapping {{ toJSON "foo" }}'
     }
   }
-  const resolvers = resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+
+  const resolvers = resolverMaker(dataSources, resolverMappings)
 
   t.deepEqual(Object.keys(resolvers), ['Query', 'Mutation', 'Subscription'])
 
@@ -47,7 +46,7 @@ test('should create Postgres resolvers successfully with no Handlebars templates
 })
 
 test('should return empty when feeded empty', t => {
-  const resolvers = resolverMaker({}, {}, {})
+  const resolvers = resolverMaker({}, {})
 
   t.deepEqual(resolvers, {
     Query: {},
@@ -57,7 +56,7 @@ test('should return empty when feeded empty', t => {
 })
 
 test('should ignore unknown operations', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -65,25 +64,23 @@ test('should ignore unknown operations', t => {
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
 
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': 'q1_requestMapping',
-        'responseMapping': 'q1_responseMapping'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': 'q1_requestMapping',
+      'responseMapping': 'q1_responseMapping'
     },
-    'UnknownOperation': {
-      'foo': {
-        'dataSource': 'p1',
-        'requestMapping': 'm1_requestMapping  {{ var }}',
-        'responseMapping': 'm1_responseMapping {{ toJSON "foo" }}'
-      }
+    'foo': {
+      'type': 'UnknownOperation',
+      'dataSource': 'p1',
+      'requestMapping': 'm1_requestMapping  {{ var }}',
+      'responseMapping': 'm1_responseMapping {{ toJSON "foo" }}'
     }
   }
-  const resolvers = resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+  const resolvers = resolverMaker(dataSources, resolverMappings)
 
   t.deepEqual(Object.keys(resolvers), ['Query', 'Mutation', 'Subscription'])
 
@@ -93,7 +90,7 @@ test('should ignore unknown operations', t => {
 })
 
 test('should throw exception when data source is not defined', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -101,24 +98,23 @@ test('should throw exception when data source is not defined', t => {
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': '',
-        'requestMapping': 'q1_requestMapping',
-        'responseMapping': 'q1_responseMapping'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': '',
+      'requestMapping': 'q1_requestMapping',
+      'responseMapping': 'q1_responseMapping'
     }
   }
 
   t.throws(() => {
-    resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+    resolverMaker(dataSources, resolverMappings)
   })
 })
 
 test('should throw exception when request mapping is not defined', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -126,24 +122,23 @@ test('should throw exception when request mapping is not defined', t => {
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': '',
-        'responseMapping': 'q1_responseMapping'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': '',
+      'responseMapping': 'q1_responseMapping'
     }
   }
 
   t.throws(() => {
-    resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+    resolverMaker(dataSources, resolverMappings)
   })
 })
 
 test('should throw exception when response mapping is not defined', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -151,40 +146,38 @@ test('should throw exception when response mapping is not defined', t => {
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': 'foo',
-        'responseMapping': ''
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': 'foo',
+      'responseMapping': ''
     }
   }
 
   t.throws(() => {
-    resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+    resolverMaker(dataSources, resolverMappings)
   })
 })
 
 test('should throw exception when the data source does not exist', t => {
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': 'q1_requestMapping',
-        'responseMapping': 'q1_responseMapping'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': 'q1_requestMapping',
+      'responseMapping': 'q1_responseMapping'
     }
   }
 
   t.throws(() => {
-    resolverMaker({}, {}, resolverMappings)
+    resolverMaker({}, resolverMappings)
   })
 })
 
 test('should throw error when there is an error in request mapping Handlebars templates', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -192,25 +185,24 @@ test('should throw error when there is an error in request mapping Handlebars te
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
 
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': '{{ var } }',
-        'responseMapping': 'q1_responseMapping {{ toJSON "foo" }}'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': '{{ var } }',
+      'responseMapping': 'q1_responseMapping {{ toJSON "foo" }}'
     }
   }
 
   t.throws(() => {
-    resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+    resolverMaker(dataSources, resolverMappings)
   })
 })
 
 test('should throw error when there is an error in response mapping Handlebars templates', t => {
-  const dataSources = {
+  const dataSourceDefs = {
     'p1': {
       'type': 'postgres',
       'config': {
@@ -218,18 +210,17 @@ test('should throw error when there is an error in response mapping Handlebars t
       }
     }
   }
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSources, false) // do not connect!
+  const dataSources = dataSourceParser(dataSourceDefs, false) // do not connect!
 
   const resolverMappings = {
-    'Query': {
-      'q1': {
-        'dataSource': 'p1',
-        'requestMapping': '{{ var }}',
-        'responseMapping': 'q1_responseMapping {{ toJSON "foo" } }'
-      }
+    'q1': {
+      'type': 'Query',
+      'dataSource': 'p1',
+      'requestMapping': '{{ var }}',
+      'responseMapping': 'q1_responseMapping {{ toJSON "foo" } }'
     }
   }
   t.throws(() => {
-    resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
+    resolverMaker(dataSources, resolverMappings)
   })
 })

--- a/server/lib/schemaParser.js
+++ b/server/lib/schemaParser.js
@@ -33,8 +33,8 @@ module.exports = function (schemaFile, dataSourcesFile, resolverMappingsFile) {
     throw new Error('Unable to read or parse RESOLVER_MAPPINGS_FILE ' + resolverMappingsFile)
   }
 
-  const {dataSourceTypes, dataSourceClients} = dataSourceParser(dataSourcesJson)
-  const resolvers = resolverMaker(dataSourceTypes, dataSourceClients, resolverMappingsJson)
+  const dataSources = dataSourceParser(dataSourcesJson)
+  const resolvers = resolverMaker(dataSources, resolverMappingsJson)
 
   return graphqlTools.makeExecutableSchema({
     typeDefs: [schemaString],


### PR DESCRIPTION
This PR doesn't introduce any new features or functionality. Just does some refactor before I move onto splitting resolvers and data sources into their own file.

Data Source Definitions used to look like this:

```json

{
  "Query": {
    "readNote": {
      "dataSource": "p1",
      "requestMapping": "SELECT id, title, content, timestamp FROM \"Notes\" WHERE id='{{context.arguments.id}}';",
      "responseMapping": "{{toJSON context.result.[0]}}"
    }
  },
  "Mutation": {
    "createNote": {
      "dataSource": "p1",
      "requestMapping": "INSERT INTO \"Notes\" (\"id\",\"title\",\"content\",\"timestamp\") VALUES ('{{context.arguments.id}}','{{context.arguments.title}}','{{context.arguments.content}}',{{context.arguments.timestamp}}) RETURNING *;",
      "responseMapping": "{{toJSON context.result.[0]}}"
    }
  }
}
```

now they look like this:

```
{
  "readNote": {
    "type": "Query",
    "dataSource": "p1",
    "requestMapping": "SELECT id, title, content, timestamp FROM \"Notes\" WHERE id='{{context.arguments.id}}';",
    "responseMapping": "{{toJSON context.result.[0]}}"
  },
  "createNote": {
    "type": "Mutation",
    "dataSource": "p1",
    "requestMapping": "INSERT INTO \"Notes\" (\"id\",\"title\",\"content\",\"timestamp\") VALUES ('{{context.arguments.id}}','{{context.arguments.title}}','{{context.arguments.content}}',{{context.arguments.timestamp}}) RETURNING *;",
    "responseMapping": "{{toJSON context.result.[0]}}"
  }
}
```

This allows for some simplification of the code in `resolverMaker.js`

I also changed the dataSourceParser to return a single object.

It used to look something like this:

```
{
	dataSourceTypes: {
		'p1': 'postgres'
	},
	dataSourceClients: {
		'p1': <Postgres Client Object>
	}
}
```

Now it looks like this:

```
{
	'p1': {type: 'postgres', client: <Client Object>}
}
```

The result of this is that the resolverMakerFunction signature has changed from this:

```
resolverMaker(dataSourceTypes, dataSourceClients, resolverMappings)
```

to this:

```
resolverMaker(dataSources, resolverMappings)
```

I was kind of struggling with mentally grasping the code and all of the objects and their relations before. I think this will really help going forward with the refactor to be done in this ticket: https://issues.jboss.org/browse/AEROGEAR-3436

I've also updated the appropriate tests