### PR TITLE
Graceful shutdown

### DIFF
--- a/server/lib/datasources/parsers/nedb.js
+++ b/server/lib/datasources/parsers/nedb.js
@@ -2,10 +2,16 @@ const Datastore = require('nedb')
 
 const type = 'InMemory'
 
-function createNEDBDatasource (config = {}, connect = true) {
-  return { client: new Datastore(config.options), type }
+function NEDBDatasource (config = {}) {
+  this.client = new Datastore(config.options)
+  this.type = type
+  this.connect = async () => {
+    // noop
+  }
+  this.disconnect = async () => {
+    this.client = undefined
+  }
+  return this
 }
 
-module.exports = {
-  createDataSource: createNEDBDatasource
-}
+module.exports = NEDBDatasource

--- a/server/lib/datasources/parsers/postgres.js
+++ b/server/lib/datasources/parsers/postgres.js
@@ -1,15 +1,16 @@
-const { Client } = require('pg')
+const {Client} = require('pg')
 
 const type = 'Postgres'
 
-function CreatePostgresDataSource (config = {}, connect = true) {
-  let client = new Client(config.options)
-  if (connect) {
-    client.connect()
+function PostgresDataSource (config = {}) {
+  this.client = new Client(config.options)
+  this.type = type
+  this.connect = async () => {
+    await this.client.connect()
   }
-  return { client, type }
+  this.disconnect = async () => {
+    await this.client.end()
+  }
 }
 
-module.exports = {
-  createDataSource: CreatePostgresDataSource
-}
+module.exports = PostgresDataSource

--- a/server/lib/resolvers/resolverMapper.js
+++ b/server/lib/resolvers/resolverMapper.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 const resolverBuilders = require('./builders')
-const { compileMappings } = require('./compiler')
+const {compileMappings} = require('./compiler')
 
 module.exports = function (dataSources, resolverMappings) {
   const resolvers = {
@@ -32,14 +32,14 @@ module.exports = function (dataSources, resolverMappings) {
       throw new Error('Unknown data source "' + resolverMapping.DataSource.name + '" for mapping ' + resolverMappingName)
     }
 
-    let { type, client } = dataSources[resolverMapping.DataSource.name]
-    let builder = resolverBuilders[type]
+    let dataSource = dataSources[resolverMapping.DataSource.name]
+    let builder = resolverBuilders[dataSource.type]
 
     if (builder) {
-      const { compiledRequestMapping, compiledResponseMapping } = compileMappings(resolverMapping.requestMapping, resolverMapping.responseMapping)
+      const {compiledRequestMapping, compiledResponseMapping} = compileMappings(resolverMapping.requestMapping, resolverMapping.responseMapping)
       if (builder.buildResolver && typeof builder.buildResolver === 'function') {
         const resolver = builder.buildResolver(
-          client,
+          dataSource.client,
           compiledRequestMapping,
           compiledResponseMapping
         )
@@ -47,10 +47,10 @@ module.exports = function (dataSources, resolverMappings) {
         resolvers[resolverMapping.type] = resolvers[resolverMapping.type] || {}
         resolvers[resolverMapping.type][resolverMappingName] = resolver
       } else {
-        throw new Error(`resolver builder for ${type} missing buildResolver function`)
+        throw new Error(`Resolver builder for ${dataSource.type} missing buildResolver function`)
       }
     } else {
-      throw new Error(`No resolver builder for type: ${type}`)
+      throw new Error(`No resolver builder for type: ${dataSource.type}`)
     }
   })
 

--- a/server/lib/schemaListeners/schemaListenerCreator.js
+++ b/server/lib/schemaListeners/schemaListenerCreator.js
@@ -1,17 +1,17 @@
 const listeners = require('./listeners')
 
 module.exports = function (schemaListenerConfig) {
-  const listenerModule = listeners[schemaListenerConfig.type]
+  const ListenerClass = listeners[schemaListenerConfig.type]
 
-  if (!listenerModule) {
+  if (!ListenerClass) {
     throw new Error(`Unhandled schema listener type: ${schemaListenerConfig.type}`)
   }
 
-  if (typeof listenerModule !== 'function') {
+  if (typeof ListenerClass !== 'function') {
     throw new Error(`Schema listener for ${schemaListenerConfig.type} is missing a constructor`)
   }
 
-  const listener = listenerModule(schemaListenerConfig.config)
+  const listener = new ListenerClass(schemaListenerConfig.config)
 
   if (!listener.start && typeof listener.start !== 'function') {
     throw new Error(`Schema listener for ${schemaListenerConfig.type} is missing "start" function`)

--- a/server/lib/schemaParser.js
+++ b/server/lib/schemaParser.js
@@ -7,8 +7,10 @@ module.exports = function (schemaString, dataSourcesJson, resolverMappingsJson) 
   const dataSources = dataSourceParser(dataSourcesJson)
   const resolvers = resolverMapper(dataSources, resolverMappingsJson)
 
-  return graphqlTools.makeExecutableSchema({
+  const schema = graphqlTools.makeExecutableSchema({
     typeDefs: [schemaString],
     resolvers: resolvers
   })
+
+  return {schema, dataSources}
 }

--- a/server/server.js
+++ b/server/server.js
@@ -52,7 +52,7 @@ module.exports = async ({graphQLConfig, graphiqlConfig, postgresConfig, schemaLi
   // Wrap the Express server
   const server = http.createServer(app)
 
-  process.on('SIGTERM', async () => {
+  const stopHandler = async () => {
     try {
       console.log('SIGTERM received. Closing connections, stopping server')
       await models.sequelize.close()
@@ -65,7 +65,12 @@ module.exports = async ({graphQLConfig, graphiqlConfig, postgresConfig, schemaLi
     } finally {
       process.exit(0)
     }
-  })
+  }
+
+  process.on('SIGTERM', stopHandler)
+  process.on('SIGABRT', stopHandler)
+  process.on('SIGQUIT', stopHandler)
+  process.on('SIGINT', stopHandler)
 
   return server
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-3646

Verify:

1. Start the app like `node index.js` (no Docker or Kube)
2. Note the PID for the process (`ps -ax | grep data-sync`)
3. Send SIGTERM: `kill -SIGTERM 1234`

I tested the same thing within Docker. 
1. Build and run the container
2. `docker stop <container>`

You will see logs.

I didn't really test stuff on Kube. It will work on Kube since it works on Docker.

Commits:
* https://github.com/aerogear/data-sync-server/pull/17/commits/31f7cddc01b2a411991013d0745ef23838ec986c: Implemented initial handler for shutdown on SIGTERM
* https://github.com/aerogear/data-sync-server/pull/17/commits/ad4bb09b76dab4e1ded73a59da68ed1cb1aa3920: Handling more signals
* https://github.com/aerogear/data-sync-server/pull/17/commits/ee0590f8d0a168b675afaa6376692fbf031f0d04: Disconnect data sources during shutdown and also during schema reload

Please note that during https://github.com/aerogear/data-sync-server/pull/17/commits/ee0590f8d0a168b675afaa6376692fbf031f0d04, I had to refactor data source parsers and data source impls to classes(types) so that they can have `connect` and `disconnect` methods.