### PR TITLE
Devl workflow for memeolist

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@ k8s_templates
 .vscode
 .circleci
 .env
+sequelize/seeders

--- a/README.md
+++ b/README.md
@@ -133,4 +133,10 @@ The baseline architecture is shown below:
 7. Logging & Metrics data is gathered from the Server & connected Clients
 
 
+## Memeolist
 
+To start the application with MemeoList schema and queries run
+```
+npm run db:init:memeo
+npm run dev:memeo
+```

--- a/examples/memeolist.query.graphql
+++ b/examples/memeolist.query.graphql
@@ -1,0 +1,42 @@
+query q1{
+  allProfiles{
+    _id
+    email
+    display_name
+    biography
+    pictureUrl
+  }
+}
+
+query q2{
+  profile(email:"asd"){
+    _id
+    email
+    display_name
+    biography
+    pictureUrl
+  }
+}
+
+mutation createProfile {
+  createProfile(email:"asd", display_name:"bla", biography:"hello", pictureUrl:"hi there"){
+    _id
+    email
+    display_name
+    biography
+    pictureUrl
+  }
+}
+
+mutation updateProfile{
+  updateProfile(id:"gCMUtAjZHfrna5FG", email:"asd2", display_name:"bla", biography:"hello", pictureUrl:"hi there")
+}
+
+mutation deleteProfile{
+  deleteProfile(id:"gCMUtAjZHfrna5FG")
+}
+
+## Notes:
+## - @isUnique for email doesn't work
+## - no login: need to pass user id with each request
+## - 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "ava",
     "start": "node ./index.js",
     "dev": "nodemon ./index.js | pino",
+    "dev:memeo": "GRAPHIQL_QUERY_FILE='examples/memeolist.query.graphql' nodemon ./index.js | pino",
     "lint": "standard",
     "format": "standard --fix",
     "docker:build": "./scripts/docker_build.sh",
@@ -29,7 +30,8 @@
     "docker:push": "./scripts/docker_push.sh",
     "docker:push:release": "./scripts/docker_push_release.sh",
     "release:validate": "./scripts/validateRelease.sh",
-    "db:init": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed:all",
+    "db:init": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed 20180704100455-notes-example.js",
+    "db:init:memeo": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed 20180711143600-memeolist-example.js",
     "db:shell": "docker exec -it aerogeardatasyncserver_postgres_1 psql -U postgresql -d aerogear_data_sync_db"
   },
   "devDependencies": {

--- a/sequelize/models/resolver.js
+++ b/sequelize/models/resolver.js
@@ -2,8 +2,8 @@ module.exports = (sequelize, DataTypes) => {
   const Resolver = sequelize.define('Resolver', {
     type: DataTypes.STRING,
     field: DataTypes.STRING,
-    requestMapping: DataTypes.STRING,
-    responseMapping: DataTypes.STRING
+    requestMapping: DataTypes.TEXT,
+    responseMapping: DataTypes.TEXT
   })
 
   Resolver.associate = (models) => {

--- a/sequelize/seeders/20180704100455-notes-example.js
+++ b/sequelize/seeders/20180704100455-notes-example.js
@@ -4,6 +4,7 @@ const time = new Date()
 
 const datasources = [
   {
+    id: 1,
     name: 'nedb_notes',
     type: 'InMemory',
     config: '{"options":{"timestampData":true}}',

--- a/sequelize/seeders/20180711143600-memeolist-example.js
+++ b/sequelize/seeders/20180711143600-memeolist-example.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const time = new Date()
+
+const datasources = [
+  {
+    id: 2,
+    name: 'nedb_memeolist',
+    type: 'InMemory',
+    config: '{"options":{"timestampData":true}}',
+    createdAt: time,
+    updatedAt: time
+  }
+]
+
+const notesSchema = {
+  name: 'default',
+  schema: `
+  
+  schema {
+    query: Query
+    mutation: Mutation
+    subscription: Subscription
+  }
+
+  type Query {
+    _: Boolean
+  }
+
+  type Mutation {
+    _: Boolean
+  }
+
+  type Subscription {
+    _: Boolean
+  }
+  
+  `,
+  createdAt: time,
+  updatedAt: time
+}
+
+const resolvers = [
+  {
+    type: 'Query',
+    field: '_',
+    DataSourceId: 2,
+    requestMapping: '{{ null }}',
+    responseMapping: '{{ null }}',
+    createdAt: time,
+    updatedAt: time
+  }
+]
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('DataSources', datasources, {})
+    await queryInterface.bulkInsert('GraphQLSchemas', [notesSchema], {})
+    return queryInterface.bulkInsert('Resolvers', resolvers, {})
+  }
+}

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -10,8 +10,8 @@ if (process.env.GRAPHIQL_QUERY_FILE) {
   try {
     graphiqlQueryFileContent = fs.readFileSync(process.env.GRAPHIQL_QUERY_FILE, 'utf-8')
   } catch (ex) {
-    console.error(`Unable to read GRAPHIQL_QUERY_FILE ${process.env.GRAPHIQL_QUERY_FILE} . Skipping it.`)
-    console.error(ex)
+    log.error(`Unable to read GRAPHIQL_QUERY_FILE ${process.env.GRAPHIQL_QUERY_FILE} . Skipping it.`)
+    log.error(ex)
   }
 }
 

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -7,7 +7,12 @@ const fs = require('fs')
 let graphiqlQueryFileContent = ''
 
 if (process.env.GRAPHIQL_QUERY_FILE) {
-  graphiqlQueryFileContent = fs.readFileSync(process.env.GRAPHIQL_QUERY_FILE).toString()
+  try {
+    graphiqlQueryFileContent = fs.readFileSync(process.env.GRAPHIQL_QUERY_FILE, 'utf-8')
+  } catch (ex) {
+    console.error(`Unable to read GRAPHIQL_QUERY_FILE ${process.env.GRAPHIQL_QUERY_FILE} . Skipping it.`)
+    console.error(ex)
+  }
 }
 
 const config = {

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -2,6 +2,14 @@
 const { log } = require('../lib/util/logger')
 require('dotenv').config()
 
+const fs = require('fs')
+
+let graphiqlQueryFileContent = ''
+
+if (process.env.GRAPHIQL_QUERY_FILE) {
+  graphiqlQueryFileContent = fs.readFileSync(process.env.GRAPHIQL_QUERY_FILE).toString()
+}
+
 const config = {
   server: {
     port: process.env.HTTP_PORT || '8000'
@@ -10,7 +18,8 @@ const config = {
     tracing: true
   },
   graphiqlConfig: {
-    endpointURL: '/graphql' // if you want GraphiQL enabled
+    endpointURL: '/graphql', // if you want GraphiQL enabled
+    query: graphiqlQueryFileContent
   },
   postgresConfig: {
     database: process.env.POSTGRES_DATABASE || 'aerogear_data_sync_db',

--- a/server/lib/resolvers/builders/nedb.js
+++ b/server/lib/resolvers/builders/nedb.js
@@ -31,10 +31,10 @@ function buildNeDBResolver (dataSourceClient, compiledRequestMapping, compiledRe
           dataSourceClient.insert(doc, mapResponse)
           break
         case 'update':
-          dataSourceClient.update(query, update, options, mapResponse)
+          dataSourceClient.update(query, update, options || {}, mapResponse)
           break
         case 'remove':
-          dataSourceClient.remove(query, options, mapResponse)
+          dataSourceClient.remove(query, options || {}, mapResponse)
           break
         default:
           return reject(new Error(`Unknown/unsupported nedb operation "${operation}"`))


### PR DESCRIPTION
@darahayes 
This PR adds 2 additional npm commands.

* db:init:memeo - Creates the DB with memeo list schema and resolvers
* dev:memeo - Feeds the memeolist example queries to Graphiql so that when you go to localhost:8000/graphiql, you can see those queries.

The schema itself is not complete. I am working on it at the moment.