### PR TITLE
Memeolist proper

### DIFF
--- a/examples/memeolist.query.graphql
+++ b/examples/memeolist.query.graphql
@@ -17,3 +17,17 @@ mutation createProfile {
         avatarUrl
     }
 }
+
+mutation updateProfile {
+    updateProfile(id:"CHANGEME", email:"michael.jordan@example.com", displayName:"Michael Jordan", biography:"Nr #23!", avatarUrl:"https://m.media-amazon.com/images/M/MV5BODgwZTQxNjctNWNjZC00ZTNiLWI2YTQtNzYzN2Y1N2IzZmMzXkEyXkFqcGdeQXVyNjcyODYyNzk@._V1_.jpg"){
+        id
+        email
+        displayName
+        biography
+        avatarUrl
+    }
+}
+
+mutation deleteProfile {
+    deleteProfile(id:"CHANGEME")
+}

--- a/examples/memeolist.query.graphql
+++ b/examples/memeolist.query.graphql
@@ -1,42 +1,19 @@
-query q1{
-  allProfiles{
-    _id
-    email
-    display_name
-    biography
-    pictureUrl
-  }
-}
-
-query q2{
-  profile(email:"asd"){
-    _id
-    email
-    display_name
-    biography
-    pictureUrl
-  }
+query allProfiles{
+    allProfiles{
+        id
+        email
+        displayName
+        biography
+        avatarUrl
+    }
 }
 
 mutation createProfile {
-  createProfile(email:"asd", display_name:"bla", biography:"hello", pictureUrl:"hi there"){
-    _id
-    email
-    display_name
-    biography
-    pictureUrl
-  }
+    createProfile(email:"jordan@example.com", displayName:"Michael Jordan", biography:"Nr #23!", avatarUrl:"https://m.media-amazon.com/images/M/MV5BODgwZTQxNjctNWNjZC00ZTNiLWI2YTQtNzYzN2Y1N2IzZmMzXkEyXkFqcGdeQXVyNjcyODYyNzk@._V1_.jpg"){
+        id
+        email
+        displayName
+        biography
+        avatarUrl
+    }
 }
-
-mutation updateProfile{
-  updateProfile(id:"gCMUtAjZHfrna5FG", email:"asd2", display_name:"bla", biography:"hello", pictureUrl:"hi there")
-}
-
-mutation deleteProfile{
-  deleteProfile(id:"gCMUtAjZHfrna5FG")
-}
-
-## Notes:
-## - @isUnique for email doesn't work
-## - no login: need to pass user id with each request
-## - 

--- a/examples/memeolist.query.graphql
+++ b/examples/memeolist.query.graphql
@@ -5,7 +5,18 @@ query allProfiles{
         displayName
         biography
         avatarUrl
+        memes {
+          id
+          photoUrl
+        }
     }
+}
+
+query allMemes{
+  allMemes{
+    id
+    photoUrl
+  }
 }
 
 mutation createProfile {
@@ -30,4 +41,11 @@ mutation updateProfile {
 
 mutation deleteProfile {
     deleteProfile(id:"CHANGEME")
+}
+
+mutation createMeme {
+  createMeme(ownerId: "u81R7GQxj7qTIH8H" photoUrl: "https://test.com"){
+    id
+    photoUrl
+  }
 }

--- a/sequelize/seeders/20180711143600-memeolist-example.js
+++ b/sequelize/seeders/20180711143600-memeolist-example.js
@@ -28,17 +28,21 @@ const notesSchema = {
   
   type Meme {
     id: ID! @isUnique
+    photoUrl: String!
+    ownerId: String!
   }
   
   type Query {
     allProfiles:[Profile!]!
     profile(email: String!):Profile
+    allMemes:[Meme!]!
   }
   
   type Mutation {
     createProfile(email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile!
     updateProfile(id: ID!, email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile
     deleteProfile(id: ID!):Boolean!
+    createMeme(ownerId: String! photoUrl: String!):Meme!
   }
   
   type Subscription {
@@ -51,6 +55,40 @@ const notesSchema = {
 }
 
 const resolvers = [
+  {
+    type: 'Query',
+    field: 'allMemes',
+    DataSourceId: 2,
+    requestMapping: '{"operation": "find", "query": {"_type":"meme"}}',
+    responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
+    createdAt: time,
+    updatedAt: time
+  },
+  {
+    type: 'Mutation',
+    field: 'createMeme',
+    DataSourceId: 2,
+    requestMapping: `{
+      "operation": "insert",
+      "doc": {
+        "_type":"meme",
+        "photoUrl": "{{context.arguments.photoUrl}}",
+        "ownerId": "{{context.arguments.ownerId}}"
+      }
+    }`,
+    responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
+    createdAt: time,
+    updatedAt: time
+  },
+  {
+    type: 'Profile',
+    field: 'memes',
+    DataSourceId: 2,
+    requestMapping: '{"operation": "find", "query": {"_type":"meme", "ownerId": "{{context.parent.id}}"}}',
+    responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
+    createdAt: time,
+    updatedAt: time
+  },
   {
     type: 'Query',
     field: 'allProfiles',

--- a/sequelize/seeders/20180711143600-memeolist-example.js
+++ b/sequelize/seeders/20180711143600-memeolist-example.js
@@ -32,12 +32,12 @@ const notesSchema = {
   
   type Query {
     allProfiles:[Profile!]!
-    profile(email: String!):Profile!
+    profile(email: String!):Profile
   }
   
   type Mutation {
     createProfile(email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile!
-    updateProfile(id: ID!, email: String!, display_name: String!, biography: String!, pictureUrl: String!):Profile!
+    updateProfile(id: ID!, email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile
     deleteProfile(id: ID!):Boolean!
   }
   
@@ -76,6 +76,41 @@ const resolvers = [
       }
     }`,
     responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
+    createdAt: time,
+    updatedAt: time
+  },
+  {
+    type: 'Mutation',
+    field: 'updateProfile',
+    DataSourceId: 2,
+    requestMapping: `{
+      "operation": "update",
+      "query": {"_type":"profile", "_id": "{{context.arguments.id}}" },
+      "update": { 
+        "$set": {
+          "email": "{{context.arguments.email}}",
+          "displayName": "{{context.arguments.displayName}}", 
+          "biography": "{{context.arguments.biography}}",    
+          "avatarUrl": "{{context.arguments.avatarUrl}}"
+        }    
+      },
+      "options": {
+        "returnUpdatedDocs": true
+      }
+    }`,
+    responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
+    createdAt: time,
+    updatedAt: time
+  },
+  {
+    type: 'Mutation',
+    field: 'deleteProfile',
+    DataSourceId: 2,
+    requestMapping: `{
+      "operation": "remove",
+      "query": {"_type":"profile", "_id": "{{context.arguments.id}}" }
+    }`,
+    responseMapping: '{{toBoolean context.result}}',
     createdAt: time,
     updatedAt: time
   }

--- a/sequelize/seeders/20180711143600-memeolist-example.js
+++ b/sequelize/seeders/20180711143600-memeolist-example.js
@@ -17,20 +17,30 @@ const notesSchema = {
   name: 'default',
   schema: `
   
-  schema {
-    query: Query
-    mutation: Mutation
-    subscription: Subscription
+  type Profile {
+    id: ID! @isUnique
+    email: String! @isUnique
+    displayName: String!
+    biography: String!
+    avatarUrl: String!
+    memes: [Meme]!
   }
-
+  
+  type Meme {
+    id: ID! @isUnique
+  }
+  
   type Query {
-    _: Boolean
+    allProfiles:[Profile!]!
+    profile(email: String!):Profile!
   }
-
+  
   type Mutation {
-    _: Boolean
+    createProfile(email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile!
+    updateProfile(id: ID!, email: String!, display_name: String!, biography: String!, pictureUrl: String!):Profile!
+    deleteProfile(id: ID!):Boolean!
   }
-
+  
   type Subscription {
     _: Boolean
   }
@@ -43,10 +53,29 @@ const notesSchema = {
 const resolvers = [
   {
     type: 'Query',
-    field: '_',
+    field: 'allProfiles',
     DataSourceId: 2,
-    requestMapping: '{{ null }}',
-    responseMapping: '{{ null }}',
+    requestMapping: '{"operation": "find", "query": {"_type":"profile"}}',
+    responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
+    createdAt: time,
+    updatedAt: time
+  },
+  {
+    type: 'Mutation',
+    field: 'createProfile',
+    DataSourceId: 2,
+    requestMapping: `{
+      "operation": "insert",
+      "doc": {
+        "_type":"profile",
+        "email": "{{context.arguments.email}}",
+        "displayName": "{{context.arguments.displayName}}",
+        "biography": "{{context.arguments.biography}}",
+        "avatarUrl": "{{context.arguments.avatarUrl}}",
+        "memes": []
+      }
+    }`,
+    responseMapping: '{{ toJSON (convertNeDBIds context.result) }}',
     createdAt: time,
     updatedAt: time
   }

--- a/server/lib/resolvers/builders/nedb.js
+++ b/server/lib/resolvers/builders/nedb.js
@@ -18,7 +18,7 @@ function buildNeDBResolver (dataSourceClient, compiledRequestMapping, compiledRe
         return reject(parsedQuery.error)
       }
 
-      const { operation, query, doc, options, update } = parsedQuery.value
+      const {operation, query, doc, options, update} = parsedQuery.value
 
       switch (operation) {
         case 'findOne':
@@ -31,7 +31,7 @@ function buildNeDBResolver (dataSourceClient, compiledRequestMapping, compiledRe
           dataSourceClient.insert(doc, mapResponse)
           break
         case 'update':
-          dataSourceClient.update(query, update, options || {}, mapResponse)
+          dataSourceClient.update(query, update, options || {}, mapUpdateResponse)
           break
         case 'remove':
           dataSourceClient.remove(query, options || {}, mapResponse)
@@ -49,7 +49,7 @@ function buildNeDBResolver (dataSourceClient, compiledRequestMapping, compiledRe
           }
         })
 
-        const { value, error } = JSONParse(responseString)
+        const {value, error} = JSONParse(responseString)
 
         if (error) {
           // TODO better error message back to user when this happens
@@ -57,6 +57,13 @@ function buildNeDBResolver (dataSourceClient, compiledRequestMapping, compiledRe
         }
 
         return resolve(value)
+      }
+
+      function mapUpdateResponse (err, numAffected, affectedDocuments) {
+        if (numAffected === 0) {
+          return mapResponse(err, [])
+        }
+        return mapResponse(err, affectedDocuments)
       }
     })
   }

--- a/server/lib/resolvers/builders/nedb.js
+++ b/server/lib/resolvers/builders/nedb.js
@@ -5,9 +5,15 @@ function buildNeDBResolver (dataSourceClient, compiledRequestMapping, compiledRe
     return new Promise((resolve, reject) => {
       const queryString = compiledRequestMapping({
         context: {
-          arguments: args
+          arguments: args,
+          parent: obj
         }
       })
+
+      console.log('obj', obj)
+      console.log('args', args)
+      console.log('context', context)
+      console.log('info', info)
 
       const parsedQuery = JSONParse(queryString)
 

--- a/server/lib/resolvers/compiler.js
+++ b/server/lib/resolvers/compiler.js
@@ -5,6 +5,20 @@ Handlebars.registerHelper('toJSON', function (json) {
   return new Handlebars.SafeString(JSON.stringify(json))
 })
 
+Handlebars.registerHelper('convertNeDBIds', function (json) {
+  if (Array.isArray(json)) {
+    for (let item of json) {
+      if (item && item._id) {
+        item.id = item._id
+      }
+    }
+  } else if (json && json._id) {
+    json.id = json._id
+  }
+
+  return json
+})
+
 function compileMappings (requestMapping, responseMapping) {
   // use Handlebars.precompile to fail early during initialization
   try {

--- a/server/lib/resolvers/compiler.js
+++ b/server/lib/resolvers/compiler.js
@@ -5,6 +5,10 @@ Handlebars.registerHelper('toJSON', function (json) {
   return new Handlebars.SafeString(JSON.stringify(json))
 })
 
+Handlebars.registerHelper('toBoolean', function (result) {
+  return new Handlebars.SafeString(!!result)
+})
+
 Handlebars.registerHelper('convertNeDBIds', function (json) {
   if (Array.isArray(json)) {
     for (let item of json) {


### PR DESCRIPTION
This PR is about trying out the Memeolist schema on our sync server as per https://issues.jboss.org/browse/AEROGEAR-3441

This is the schema defined in the proposal: https://github.com/secondsun/proposals/blob/eb4bc07e472f9a96ee1d69c491f772ecb484eabb/dogfood.md#sample-schema

Trying out a real world example as a user helps with finding bugs and limitations.
I didn't just put the whole schema and then try to write resolvers. I am going step by step.

Here are the issues found so far:
* NeDB uses `_id` as the id field name. This causes portability issues such as a schema itself needs to be updated when switching the data source. Ideally, only the resolvers should've changed, not the schema.
As a solution to that, I implemented a 'convertNeDBIds' Handlebars helper that would convert `_id`s to `id`s. With this change, types in schemas can still use `id` as the id field.

* NeDB doesn't have an option to return the deleted docs. It only returns the number of deleted docs. So, the delete query definitions should be changed to return a number (num deleted) or boolean (if something is deleted).
I have also implemented a `toBoolean` helper to use in resolvers that could be useful in this case.

* In NeDB unlike queries and inserts, update operation's callback have a different signature. Needed to adapt the NeDB resolver builder.

* NeDB supports unique indices, but they need to be created in advance. We are not planning to support this with in mem data source. This should be documented.

Tasks:
- [X] allProfiles (query) : simple query
- [X] profile (query) : another simple query, but make sure the return result is proper when no profile found
- [X] createProfile
- [X] updateProfile
- [X] deleteProfile
- [ ] postMeme : Need to use NeDB's `$addToSet` or `$push` to insert stuff into `profile` doc's `memes` property
- [ ] allMemes: Get all `profile.memes` and order them by create/update time
- [ ] deleteMeme: Need to use  NeDb's `$pull`
- [ ] postComment: Insert a comment into `profile.memes[].comments[]`
- [ ] deleteComment
- [ ] What about the timestamps like `meme.createdOn`? Make it working properly with GraphQL and NeDB.
- [ ] Graphql returns an error instead of null when an object not found: https://stackoverflow.com/questions/51287139/graphql-return-a-type-with-non-nullable-id-field-as-a-query-result/51293035#51293035

**NOTE: We don't have to use the schema in the proposal as-is. For example, that schema doesn't accept a profile id in the `postMeme` mutation because it has the assumption that there's an auth in place. We should just add the profile id param to `postMeme`** 