### PR TITLE
hack: allow db:init:memeo run inside container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,10 +8,7 @@ README.md
 examples
 *.png
 nodemon.json
-.sequelizerc
-scripts
 k8s_templates
 .vscode
 .circleci
 .env
-sequelize/seeders

--- a/package-lock.json
+++ b/package-lock.json
@@ -3556,9 +3556,9 @@
       "integrity": "sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag=="
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-port": {
@@ -6193,7 +6193,7 @@
             "camelcase": "4.1.0",
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
+            "get-caller-file": "1.0.3",
             "os-locale": "2.1.0",
             "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ava": "1.0.0-beta.6",
     "nodemon": "^1.17.5",
     "pre-commit": "^1.2.2",
-    "sequelize-cli": "^4.0.0",
     "standard": "^11.0.1"
   },
   "dependencies": {
@@ -59,6 +58,7 @@
     "pg-pubsub": "^0.4.0",
     "pino": "^4.17.3",
     "sequelize": "^4.38.0",
+    "sequelize-cli": "^4.0.0",
     "subscriptions-transport-ws": "^0.9.11"
   },
   "pre-commit": [


### PR DESCRIPTION
This PR makes some changes such that it's possible to run `npm run db:init:memeo' inside the running container image.

This allows us to do a little hack where we can use the OpenShift UI to get a shell inside the running container and then we can manually execute `npm run db:init:memeo`. This will enable us to do the demo.

