### PR TITLE
fix: ensure handlebars does not escape unicode characters

### DIFF
--- a/server/lib/resolvers/compiler.js
+++ b/server/lib/resolvers/compiler.js
@@ -25,6 +25,7 @@ Handlebars.registerHelper('convertNeDBIds', function (json) {
 
 function compileMappings (requestMapping, responseMapping) {
   // use Handlebars.precompile to fail early during initialization
+  const noEscape = true
   try {
     Handlebars.precompile(requestMapping)
   } catch (ex) {
@@ -41,8 +42,8 @@ function compileMappings (requestMapping, responseMapping) {
     throw (ex)
   }
 
-  const compiledRequestMapping = Handlebars.compile(requestMapping)
-  const compiledResponseMapping = Handlebars.compile(responseMapping)
+  const compiledRequestMapping = Handlebars.compile(requestMapping, { noEscape })
+  const compiledResponseMapping = Handlebars.compile(responseMapping, { noEscape })
 
   return { compiledRequestMapping, compiledResponseMapping }
 }


### PR DESCRIPTION
I found an issue where the handlebars templates (request and response mappings) would escape unicode characters. For example, in the memeolist app this led to the `photoUrl` property being broken and it meant that in the app, the image could not be displayed

ping @aliok @wtrocki 