### PR TITLE
AEROGEAR-7646

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-console": "error"
+  },
+  "extends": "standard"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2107,7 +2107,7 @@
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
+        "eslint-scope": "3.7.3",
         "eslint-visitor-keys": "1.0.0",
         "espree": "3.5.4",
         "esquery": "1.0.1",
@@ -2233,13 +2233,22 @@
         }
       }
     },
-    "eslint-plugin-import": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
-      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+    "eslint-plugin-es": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz",
+      "integrity": "sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
+        "eslint-utils": "1.3.1",
+        "regexpp": "2.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",
+      "integrity": "sha512-t6hGKQDMIt9N8R7vLepsYXgDfeuhp6ZJSgtrLEDxonpSubyxUZHjhm6LsAaZX8q6GYVxkbT3kTsV9G5mBCFR6A==",
+      "dev": true,
+      "requires": {
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
@@ -2248,7 +2257,8 @@
         "has": "1.0.3",
         "lodash": "4.17.10",
         "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "doctrine": {
@@ -2321,17 +2331,25 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.10",
+        "eslint-plugin-es": "1.3.1",
+        "eslint-utils": "1.3.1",
+        "ignore": "4.0.2",
         "minimatch": "3.0.4",
         "resolve": "1.8.1",
         "semver": "5.5.0"
       },
       "dependencies": {
+        "ignore": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.2.tgz",
+          "integrity": "sha512-uoxnT7PYpyEnsja+yX+7v49B7LXxmzDJ2JALqHH3oEGzpM2U1IGcbfnOr8Dt57z3B/UWs7/iAgPFbmye8m4I0g==",
+          "dev": true
+        },
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -2341,9 +2359,9 @@
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
-      "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
+      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
       "dev": true
     },
     "eslint-plugin-react": {
@@ -2359,20 +2377,26 @@
       }
     },
     "eslint-plugin-standard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
+      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
       "dev": true
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "4.2.1",
         "estraverse": "4.2.0"
       }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -5724,6 +5748,12 @@
         "safe-regex": "1.1.0"
       }
     },
+    "regexpp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
+      "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA==",
+      "dev": true
+    },
     "regexpu-core": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
@@ -6529,6 +6559,123 @@
         "eslint-plugin-react": "7.7.0",
         "eslint-plugin-standard": "3.0.1",
         "standard-engine": "8.0.1"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
+          "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1",
+            "contains-path": "0.1.0",
+            "debug": "2.6.9",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "0.3.2",
+            "eslint-module-utils": "2.2.0",
+            "has": "1.0.3",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "read-pkg-up": "2.0.0"
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
+          "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+          "dev": true,
+          "requires": {
+            "ignore": "3.3.10",
+            "minimatch": "3.0.4",
+            "resolve": "1.8.1",
+            "semver": "5.5.0"
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.7.0.tgz",
+          "integrity": "sha512-2WO+ZFh7vxUKRfR0cOIMrWgYKdR6S1AlOezw6pC52B6oYpd5WFghN+QHxvrRdZMtbo8h3dfUZ2o1rWb0UPbKtg==",
+          "dev": true
+        },
+        "eslint-plugin-standard": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+          "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.2"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
       }
     },
     "standard-engine": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "start": "node ./index.js",
     "dev": "nodemon ./index.js | pino",
     "dev:memeo": "GRAPHIQL_QUERY_FILE='examples/memeolist.query.graphql' nodemon ./index.js | pino",
-    "lint": "standard",
-    "format": "standard --fix",
+    "lint": "eslint **/*.js",
+    "format": "eslint **/*.js --fix",
     "docker:build": "./scripts/docker_build.sh",
     "docker:build:release": "./scripts/docker_build_release.sh",
     "docker:push": "./scripts/docker_push.sh",
@@ -40,6 +40,11 @@
   "devDependencies": {
     "apollo-fetch": "^0.7.0",
     "ava": "1.0.0-beta.6",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0",
     "nodemon": "^1.17.5",
     "pre-commit": "^1.2.2",
     "standard": "^11.0.1"

--- a/scripts/sync_models.js
+++ b/scripts/sync_models.js
@@ -4,7 +4,6 @@ const forceDrop = process.env.FORCE_DROP === 'true'
 
 if (require.main === module) {
   require('../sequelize/models')(postgresConfig).sequelize.sync({force: forceDrop}).then(() => {
-    console.log('sequelize done')
     process.exit(0)
   })
 } else {


### PR DESCRIPTION
Review the code to make sure console.log/.info/.error/etc. is not used. Configure linter to complain about "console" usage

StandardJS is just a wrapper around ESLint with custom ruleset. It makes sense in 99% cases but we want to disable the usage of `console`. I had to use sharable configs feature of ESLint and extend StandardJS rules by `no-console` rule.

How to verify:

### 1. Console
add `console.log('foo')` to somewhere and run `npm run lint`. You should see failure.

### 2. Formatter
Make sure the formatter still works. 
* Change a single quoted string to double quoted string
* Run `npm run format`
* The string should be quoted with single quites