### PR TITLE
AEROGEAR-7727 provide a way to enable/disable audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The DevTools window should automatically connect to the debugging session and ex
 
 This server requires a bunch of environment variables to be set. If they're not set, defaults for development will be used.
 
+* `AUDIT_LOGGING`:   : If true, audit logs of resolver operations will be logged to stdout. Defaults to true.
 * `POSTGRES_DATABASE`: Name of the Postgres database. Defaults to `aerogear_data_sync_db`
 * `POSTGRES_USERNAME`: Username to use when connecting Postgres. Defaults to `postgresql`
 * `POSTGRES_PASSWORD`: Password to use when connecting Postgres. Defaults to `postgres`

--- a/server/lib/util/logger.js
+++ b/server/lib/util/logger.js
@@ -1,18 +1,22 @@
 const log = require('pino')()
 const auditLogger = log.child({tag: 'AUDIT'})
 
+const auditLogEnabled = process.env.AUDIT_LOGGING !== 'false' && process.env.AUDIT_LOGGING !== false
+
 function auditLog (success, request, info, parent, args, msg) {
-  auditLogger.info({
-    msg: msg || '',
-    requestId: request.id,
-    operationType: info.operation.operation,
-    fieldName: info.fieldname,
-    parentTypeName: info.parentType.name,
-    path: buildPath(info.path),
-    success: success,
-    parent: parent,
-    arguments: args
-  })
+  if (auditLogEnabled) {
+    auditLogger.info({
+      msg: msg || '',
+      requestId: request.id,
+      operationType: info.operation.operation,
+      fieldName: info.fieldname,
+      parentTypeName: info.parentType.name,
+      path: buildPath(info.path),
+      success: success,
+      parent: parent,
+      arguments: args
+    })
+  }
 }
 
 // builds path for a GraphQL operation


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-7727

Verify: set AUDIT_LOGGING env var to false and you shall not see any audit logs.
Audit logging is enabled by default.