### PR TITLE
fix: Subscriptions Hot Reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,19 +2,19 @@ const config = require('./server/config')
 const DataSyncService = require('./DataSyncService')
 const { log } = require('./server/lib/util/logger')
 
+process.on('uncaughtException', log.error.bind(log))
+process.on('unhandledRejection', log.error.bind(log))
+
 async function start () {
   const syncService = new DataSyncService(config)
-  await syncService.initialize()
-  await syncService.start()
-
   const stopSignals = ['SIGTERM', 'SIGABRT', 'SIGQUIT', 'SIGINT']
 
   stopSignals.forEach(signal => {
     process.on(signal, syncService.gracefulShutdown.bind(syncService, signal))
   })
 
-  process.on('uncaughtException', log.error.bind(log))
-  process.on('unhandledRejection', log.error.bind(log))
+  await syncService.initialize()
+  await syncService.start()
 }
 
 start()

--- a/integration_test/subscriptions.hot.reload.integration.test.js
+++ b/integration_test/subscriptions.hot.reload.integration.test.js
@@ -1,0 +1,118 @@
+const { test } = require('ava')
+const Helper = require('./helper')
+const TestApolloClient = require('./util/testApolloClient')
+const gql = require('graphql-tag')
+
+const context = {
+  apolloClient: null,
+  helper: null
+}
+
+test.before(async t => {
+  context.apolloClient = new TestApolloClient()
+  const helper = new Helper()
+
+  await helper.initialize()
+
+  // delete the all the config 1-time before starting the tests
+  await helper.deleteConfig()
+  await helper.feedConfig('complete.postgres.valid.memeo.js')
+  await helper.cleanMemeolistDatabase(t)
+  await helper.syncService.restart()
+  context.helper = helper
+})
+
+test.serial('Newly added subscriptions should be hot reloaded', async (t) => {
+  const { helper, apolloClient } = context
+
+  const newSchemaString = `
+
+    type Profile {
+        id: ID! @isUnique
+        email: String! @isUnique
+        displayName: String!
+        biography: String!
+        avatarUrl: String!
+        memes: [Meme]!
+    }
+
+    type Meme {
+        id: ID! @isUnique
+        photoUrl: String!
+        ownerId: String!
+    }
+
+    type Query {
+        allProfiles:[Profile!]!
+        profile(email: String!):Profile
+        allMemes:[Meme!]!
+    }
+
+    type Mutation {
+        createProfile(email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile!
+        updateProfile(id: ID!, email: String!, displayName: String!, biography: String!, avatarUrl: String!):Profile
+        deleteProfile(id: ID!):Boolean!
+        createMeme(ownerId: String!, photoUrl: String!):Meme!
+    }
+
+    type Subscription {
+      memeAdded(photoUrl: String):Meme!
+      profileAdded:Profile
+    }
+
+  `
+
+  const newSubscription = {
+    type: 'Subscription',
+    field: 'profileAdded',
+    GraphQLSchemaId: 2
+  }
+
+  const publish = newSubscription.field
+
+  // update existing schema, subscriptions and resolvers to enable a 'profileAdded' subscription
+  await helper.models.GraphQLSchema.update({ schema: newSchemaString }, { where: { name: 'default' } })
+  await helper.models.Subscription.build(newSubscription).save()
+  await helper.models.Resolver.update({ publish }, { where: { field: 'createProfile' } })
+
+  // trigger the hot reload
+  await context.helper.triggerReload()
+
+  // let's try test that our new subscription works
+  let subscription = apolloClient.subscribe(gql`
+    subscription profileAdded {
+      profileAdded {
+        id,
+        email,
+        displayName,
+        biography,
+        avatarUrl
+      }
+    }
+  `)
+
+  await apolloClient.client.mutate({
+    // language=GraphQL
+    mutation: gql`
+    mutation {
+      createProfile (
+          email: "jordan@example.com",
+          displayName: "Michael Jordan",
+          biography:"Nr #23!",
+          avatarUrl:"http://example.com/mj.jpg"
+      ) {
+          id,
+          email,
+          displayName,
+          biography,
+          avatarUrl
+      }
+      }
+    `
+  })
+
+  let result = await subscription
+
+  t.truthy(result)
+  t.truthy(result.data.profileAdded)
+})

--- a/sequelize/seeders/memeolist-example-shared.js
+++ b/sequelize/seeders/memeolist-example-shared.js
@@ -9,7 +9,7 @@ const subscriptions = [
     GraphQLSchemaId: 1,
     topic: 'memeCreated',
     filter: JSON.stringify({
-      match: ['$payload.memeAdded.photoUrl', 'https://.*']
+      match: ['$payload.memeAdded.photourl', 'https://.*']
     }),
     createdAt: time,
     updatedAt: time

--- a/server/server.js
+++ b/server/server.js
@@ -13,10 +13,6 @@ const { SubscriptionServer } = require('subscriptions-transport-ws')
 const schemaParser = require('./lib/schemaParser')
 const schemaListenerCreator = require('./lib/schemaListeners/schemaListenerCreator')
 
-http.Server.prototype.startListening = function (port) {
-
-}
-
 module.exports = async ({graphQLConfig, graphiqlConfig, postgresConfig, schemaListenerConfig}, models, pubsub) => {
   const {tracing} = graphQLConfig
   let {schema, dataSources} = await buildSchema(models, pubsub)

--- a/server/server.js
+++ b/server/server.js
@@ -66,6 +66,10 @@ module.exports = async ({graphQLConfig, graphiqlConfig, postgresConfig, schemaLi
       }
 
       if (newSchema) {
+        schema = newSchema.schema
+        subscriptionServer.close()
+        subscriptionServer = newSubscriptionServer(server, schema)
+
         try {
           await disconnectDataSources(dataSources) // disconnect existing ones first
         } catch (ex) {
@@ -76,10 +80,7 @@ module.exports = async ({graphQLConfig, graphiqlConfig, postgresConfig, schemaLi
 
         try {
           await connectDataSources(newSchema.dataSources)
-          schema = newSchema.schema
           dataSources = newSchema.dataSources
-          subscriptionServer.close()
-          subscriptionServer = newSubscriptionServer(server, schema)
         } catch (ex) {
           log.error('Error while connecting to new data sources')
           log.error(ex)


### PR DESCRIPTION
This PR ensures that the subscription server is closed and that a new one is instantiated when a schema change occurs.

It also adds an integration test to test this case.

It also makes a few minor changes in startup sequence:
	* add the unhandledRejection and unhandledException listeners at the very beginning. Because these were being added **after** initialisation + startup, any errors happening in that time would be swallowed
	* Same thing again for the stop signals listeners