### PR TITLE
fix: add extra context to pre and post hook payload

### DIFF
--- a/server/lib/resolvers/resolverMapper.js
+++ b/server/lib/resolvers/resolverMapper.js
@@ -1,8 +1,8 @@
 const _ = require('lodash')
+const axios = require('axios')
 const resolverBuilders = require('./builders')
 const { compile } = require('./compiler')
 const { wrapResolverWithPublish } = require('./wrapResolverWithPublisher')
-const axios = require('axios')
 const { wrapResolverWithHooks } = require('./wrapResolverWithHooks')
 
 module.exports = function (dataSources, resolverMappings, pubsub) {

--- a/server/lib/resolvers/wrapResolverWithHooks.test.js
+++ b/server/lib/resolvers/wrapResolverWithHooks.test.js
@@ -2,9 +2,25 @@ const {test} = require('ava')
 const {wrapResolverWithHooks} = require('./wrapResolverWithHooks')
 
 test('it should check the prehoook url', t => {
+  // mock arguments for a GraphQL resolver function
+  const obj = {}
+  const args = { hello: 'world' }
+  const context = {}
+  const info = {
+    operation: {
+      operation: 'someOperation'
+    },
+    parentType: {
+      name: 'someName'
+    },
+    fieldName: 'someField'
+  }
+
+  let expectedResolverResult = 'some result'
+
   let originalResolver = function () {
     return new Promise((resolve) => {
-      return resolve()
+      return resolve(expectedResolverResult)
     })
   }
 
@@ -12,24 +28,41 @@ test('it should check the prehoook url', t => {
     preHook: 'http://prehook.com'
   }
 
-  const requestObject = {
-    post: function (url) {
+  const httpClient = {
+    post: function (url, payload) {
       t.deepEqual(url, 'http://prehook.com')
+      t.deepEqual(payload.args, args)
       return new Promise(function (resolve, reject) { })
     }
   }
 
-  const wrappedResolver = wrapResolverWithHooks(originalResolver, resolverMapping, requestObject)
+  const wrappedResolver = wrapResolverWithHooks(originalResolver, resolverMapping, httpClient)
 
   t.truthy(wrappedResolver)
   t.deepEqual(typeof wrappedResolver, 'function')
-  return wrappedResolver()
+  return wrappedResolver(obj, args, context, info)
 })
 
 test('it should check the posthoook url', t => {
+  // mock arguments for a GraphQL resolver function
+  const obj = {}
+  const args = { hello: 'world' }
+  const context = {}
+  const info = {
+    operation: {
+      operation: 'someOperation'
+    },
+    parentType: {
+      name: 'someName'
+    },
+    fieldName: 'someField'
+  }
+
+  let expectedResolverResult = 'some result'
+
   let originalResolver = function () {
     return new Promise((resolve) => {
-      return resolve()
+      return resolve(expectedResolverResult)
     })
   }
 
@@ -37,16 +70,17 @@ test('it should check the posthoook url', t => {
     postHook: 'http://posthook.com'
   }
 
-  const requestObject = {
-    post: function (url) {
+  const httpClient = {
+    post: function (url, payload) {
       t.deepEqual(url, 'http://posthook.com')
+      t.deepEqual(payload.result, expectedResolverResult)
       return new Promise(function (resolve, reject) { })
     }
   }
 
-  const wrappedResolver = wrapResolverWithHooks(originalResolver, resolverMapping, requestObject)
+  const wrappedResolver = wrapResolverWithHooks(originalResolver, resolverMapping, httpClient)
 
   t.truthy(wrappedResolver)
   t.deepEqual(typeof wrappedResolver, 'function')
-  return wrappedResolver()
+  return wrappedResolver(obj, args, context, info)
 })


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-7764

## What

Adds additional context to the pre and post hook payloads

## Verification Steps

This really isn't necessary, however if you would like to verify you can run a test hook server as follows:

```
docker run -p 3000:3000 darahayes/echo-server | npx pino-pretty
```

Then go edit the `createMeme` resolver inside `sequelize/seeders/memeolist-example-postgres.js` to have these extra fields:

```
preHook: 'http://localhost:3000',
postHook: 'http://localhost:3000'
```

Then run the sync server as follows

```
npm run db:init:memeo:postgres && npm run dev:memeo
```

Now use the GraphiQL interface to create a profile, then create a meme.

Go back to the logs for the `echo-server` and you should see some logs similar to the following:

```
# preHook
[1534323262218] INFO (73692 on Daras-MacBook-Pro.local):
    hookType: "preHook"
    operationType: "mutation"
    parentTypeName: "Mutation"
    path: "createMeme"
    args: {
      "ownerid": "1",
      "photourl": "https://i.imgur.com/W4dhL0b.jpg",
      "owner": "mmartini"
    }
```

```
# postHook
[1534323262230] INFO (73692 on Daras-MacBook-Pro.local):
    hookType: "postHook"
    operationType: "mutation"
    parentTypeName: "Mutation"
    path: "createMeme"
    result: {
      "id": 2,
      "photourl": "https://i.imgur.com/W4dhL0b.jpg",
      "owner": "mmartini",
      "likes": "0",
      "ownerid": 1
    }
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

 

