### PR TITLE
feat: initial empty hasRole implementation

### DIFF
--- a/server/lib/schemaDirectives/hasRole.js
+++ b/server/lib/schemaDirectives/hasRole.js
@@ -1,0 +1,19 @@
+const { SchemaDirectiveVisitor } = require('graphql-tools')
+const { defaultFieldResolver } = require('graphql')
+const { log } = require('../util/logger')
+
+class HasRoleDirective extends SchemaDirectiveVisitor {
+  visitFieldDefinition (field) {
+    const { resolve = defaultFieldResolver } = field
+    const { role } = this.args
+    field.resolve = async function (root, args, context, info) {
+      log.info('checking has role directive', role)
+      // TODO - figure out how to check does the logged in user have the correct role
+      // using the keycloak-connect library
+      const result = await resolve.apply(this, [root, args, context, info])
+      return result
+    }
+  }
+}
+
+module.exports = HasRoleDirective

--- a/server/lib/schemaDirectives/hasRole.js
+++ b/server/lib/schemaDirectives/hasRole.js
@@ -8,6 +8,8 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
     const { role } = this.args
     field.resolve = async function (root, args, context, info) {
       log.info('checking has role directive', role)
+      log.info('Printing user', context.request.session)
+      // context.request.kauth.grant.access_token.hasRealmRole(role)
       // TODO - figure out how to check does the logged in user have the correct role
       // using the keycloak-connect library
       const result = await resolve.apply(this, [root, args, context, info])

--- a/server/lib/schemaDirectives/hasRole.js
+++ b/server/lib/schemaDirectives/hasRole.js
@@ -9,9 +9,8 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
     field.resolve = async function (root, args, context, info) {
       log.info('checking has role directive', role)
       log.info('Printing user', context.request.session)
-      // context.request.kauth.grant.access_token.hasRealmRole(role)
-      // TODO - figure out how to check does the logged in user have the correct role
-      // using the keycloak-connect library
+      // TODO if (context.request.kauth.grant.access_token.hasRealmRole(role))
+      // Return appropriate error if this is false
       const result = await resolve.apply(this, [root, args, context, info])
       return result
     }

--- a/server/lib/schemaParser.js
+++ b/server/lib/schemaParser.js
@@ -3,6 +3,8 @@ const dataSourceParser = require('./datasources/dataSourceParser')
 const resolverMapper = require('./resolvers/resolverMapper')
 const subscriptionsMapper = require('./subscriptions/subscriptionMapper')
 
+const HasRoleDirective = require('./schemaDirectives/hasRole')
+
 module.exports = function (schemaString, dataSourcesJson, resolverMappingsJson, subscriptionMappingsJson, pubsub) {
   const dataSources = dataSourceParser(dataSourcesJson)
   const subscriptionResolvers = subscriptionsMapper(subscriptionMappingsJson, pubsub)
@@ -12,7 +14,10 @@ module.exports = function (schemaString, dataSourcesJson, resolverMappingsJson, 
 
   const schema = makeExecutableSchema({
     typeDefs: [schemaString],
-    resolvers
+    resolvers: resolvers,
+    schemaDirectives: {
+      hasRole: HasRoleDirective
+    }
   })
 
   return {schema, dataSources}


### PR DESCRIPTION
## Motivation

This PR provides a skeleton implementation for a `hasRole` directive which can be applied to a schema.

https://www.apollographql.com/docs/graphql-tools/schema-directives.html#Enforcing-access-permissions

This skeleton implementation is where we can now figure out how to do the integration with keycloak.