### PR TITLE
AG-7815 refactor newExpressApp function 

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release:validate": "./scripts/validateRelease.sh",
     "db:init": "FORCE_DROP=true node ./scripts/sync_models",
     "db:init:memeo:inmem": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-inmem.js",
-    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec datasyncserver_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
+    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec aerogeardatasyncserver_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
     "db:shell": "docker exec -it datasyncserver_postgres_1 psql -U postgresql -d aerogear_data_sync_db",
     "db:shell:memeo": "docker exec -it datasyncserver_postgres_memeo_1 psql -U postgresql -d memeolist_db"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release:validate": "./scripts/validateRelease.sh",
     "db:init": "FORCE_DROP=true node ./scripts/sync_models",
     "db:init:memeo:inmem": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-inmem.js",
-    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec aerogeardatasyncserver_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
+    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec datasyncserver_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
     "db:shell": "docker exec -it datasyncserver_postgres_1 psql -U postgresql -d aerogear_data_sync_db",
     "db:shell:memeo": "docker exec -it datasyncserver_postgres_memeo_1 psql -U postgresql -d memeolist_db"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -71,19 +71,19 @@ module.exports = async ({graphQLConfig,
 
   let graphqlEndpoint = graphQLConfig.graphqlEndpoint
 
-  const options = {
+  const expressAppOptions = {
     keycloakConfig,
     graphqlEndpoint,
     models
   }
 
-  const middlewares = {
+  const expressAppMiddlewares = {
     metrics: getMetrics,
     responseLoggingMetric,
     logging: expressPino
   }
 
-  let app = newExpressApp(options, middlewares)
+  let app = newExpressApp(expressAppOptions, expressAppMiddlewares)
   let apolloServer = newApolloServer(app, schema, server, tracing, playgroundConfig, graphqlEndpoint)
   server.on('request', app)
 
@@ -114,7 +114,7 @@ module.exports = async ({graphQLConfig,
         server.removeListener('request', app)
         // reinitialize the server objects
         schema = newSchema.schema
-        app = newExpressApp(options, middlewares)
+        app = newExpressApp(expressAppOptions, expressAppMiddlewares)
         apolloServer = newApolloServer(app, schema, server, tracing, playgroundConfig)
         server.on('request', app)
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7815

## What
Fix the bug where the healthz endpoint was returning a 404 after a schema reload

## Why
Causing health checks on Openshift to fail

## How
Move the code into the newExpressApp function as suggested in the jira

## Verification Steps

- run the server & seed db
- run the ui
- hit the server url + /healthz in the browser - should get message : 
    `{"ok":true,"checks":[{"Database Connectivity":true}]}`
- make a change in the ui such as add a data source which will trigger a schema reload
- verify the endpoint is still giving a healthy response as above and not a 404

@darahayes I think I have implemented this as you suggested - I was able to replicate the issue locally using the method I described
## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes
