### PR TITLE
Use 'sync' prefix for container names

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Currently only Postgres channel listening is supported.
    Use docker compose to start the database(s).
 
    ```shell
-   docker-compose up
+   docker-compose --project-name=sync up
    ```
 
    There are 2 Postgres instances defined in docker-compose configuration:

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "release:validate": "./scripts/validateRelease.sh",
     "db:init": "FORCE_DROP=true node ./scripts/sync_models",
     "db:init:memeo:inmem": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-inmem.js",
-    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec data-sync-server_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
-    "db:shell": "docker exec -it data-sync-server_postgres_1 psql -U postgresql -d aerogear_data_sync_db",
-    "db:shell:memeo": "docker exec -it data-sync-server_postgres_memeo_1 psql -U postgresql -d memeolist_db"
+    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec sync_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
+    "db:shell": "docker exec -it sync_postgres_1 psql -U postgresql -d aerogear_data_sync_db",
+    "db:shell:memeo": "docker exec -it sync_postgres_memeo_1 psql -U postgresql -d memeolist_db"
   },
   "devDependencies": {
     "apollo-cache-inmemory": "^1.3.0-beta.6",


### PR DESCRIPTION
## Motivation
Discussion in https://github.com/aerogear/data-sync-server/pull/63#discussion_r212248759
## What
* Change container names in `package.json` to `sync_` so the default command to run the db locally would be `docker-compose -p sync up`
* Specify this in the readme
## Why
To resolve this issue for good 👺 
## Verification Steps
1. Clone this branch, run `docker-compose --project-name=sync up` (see [readme](https://github.com/aerogear/data-sync-server/compare/clarify-docker-compose-usage?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R91))
2. Run 
```
npm run db:shell
# Should log in to aerogear_data_sync_db
npm run db:shell:memeo
# Should log in to memeolist_db
npm run db:init:memeo:postgres
# Should run the db seeding without error
```
## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 
 

