### PR TITLE
fix: add smoke test for server startup

### DIFF
--- a/integration_test/datasyncservice.smoke.test.js
+++ b/integration_test/datasyncservice.smoke.test.js
@@ -1,0 +1,18 @@
+const { test } = require('ava')
+const axios = require('axios')
+const DataSyncService = require('../DataSyncService')
+const config = require('../server/config')
+
+test.serial('The DataSyncService class successfully initializes and starts', async (t) => {
+  config.server.port = 0 // specifying port 0 gives us a random port number to make sure it doesn't conflict with anything
+  t.plan(2)
+  const syncService = new DataSyncService(config)
+  await syncService.initialize()
+  await syncService.start()
+
+  let { port } = syncService.app.server.address()
+
+  const response = await axios.get(`http://localhost:${port}/healthz`)
+  t.deepEqual(response.status, 200)
+  t.pass()
+})


### PR DESCRIPTION
## Motivation

This small integration test is a smoke test that ensures that the actual `DataSyncService` class can be initialised and started. All of the other tests don't actually verify this because we use a special `RestartableSyncService` class for the rest of the tests.

This is important because this is the actual class that is used in a real scenario and also this should bump our code coverage.

