### PR TITLE
fix: unit tests for keycloak hasRole and AuthContextProvider implementations

### DIFF
--- a/server/security/services/keycloak/AuthContextProvider.test.js
+++ b/server/security/services/keycloak/AuthContextProvider.test.js
@@ -1,0 +1,27 @@
+const { test } = require('ava')
+const AuthContextProvider = require('./AuthContextProvider')
+
+test('provider.getToken() returns request.kauth.grant.access_token', (t) => {
+  const token = {
+    someField: 'foo'
+  }
+  const request = {
+    kauth: {
+      grant: {
+        access_token: token
+      }
+    }
+  }
+
+  const provider = new AuthContextProvider(request)
+  t.truthy(provider.getToken())
+  t.deepEqual(provider.request, request)
+  t.deepEqual(provider.getToken(), token)
+})
+
+test('provider.getToken() returns null when request.kauth is not available', (t) => {
+  const request = {}
+
+  const provider = new AuthContextProvider(request)
+  t.falsy(provider.getToken())
+})

--- a/server/security/services/keycloak/schemaDirectives/hasRole.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.js
@@ -9,11 +9,12 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
     const allowedTypes = ['client', 'realm']
     let { role, type } = this.args
 
+    type = type || 'client' // default to client if a type is not specified
+
     const typeErrorMessage = `type argument in hasRole directive must be one of ${allowedTypes}`
     const permissionErrorMessage = `logged in user does not have sufficient permissions for ${field.name}: missing role ${role}`
 
     field.resolve = async function (root, args, context, info) {
-      type = type || 'client'
       if (!allowedTypes.includes(type)) {
         log.info(typeErrorMessage)
         throw new Error(typeErrorMessage)
@@ -22,12 +23,12 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
       if (type === 'realm') {
         if (!context.auth.getToken().hasRealmRole(role)) {
           log.info(permissionErrorMessage)
-          return new ForbiddenError(permissionErrorMessage)
+          throw new ForbiddenError(permissionErrorMessage)
         }
       } else {
         if (!context.auth.getToken().hasRole(role)) {
           log.info(permissionErrorMessage)
-          return new ForbiddenError(permissionErrorMessage)
+          throw new ForbiddenError(permissionErrorMessage)
         }
       }
 

--- a/server/security/services/keycloak/schemaDirectives/hasRole.test.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.test.js
@@ -1,0 +1,244 @@
+const { test } = require('ava')
+const HasRoleDirective = require('./hasRole')
+
+test('context.auth.hasRole is called when type is client', async (t) => {
+  t.plan(3)
+  const directiveArgs = {
+    role: 'admin',
+    type: 'client'
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      t.pass()
+    }
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {
+    auth: {
+      getToken: () => {
+        return {
+          hasRole: (role) => {
+            t.pass()
+            t.deepEqual(role, directiveArgs.role)
+            return true
+          }
+        }
+      }
+    }
+  }
+  const info = {}
+
+  await field.resolve(root, args, context, info)
+})
+
+test('context.auth.hasRealmRole is called when type is realm', async (t) => {
+  t.plan(3)
+  const directiveArgs = {
+    role: 'admin',
+    type: 'realm'
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      t.pass()
+    }
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {
+    auth: {
+      getToken: () => {
+        return {
+          hasRealmRole: (role) => {
+            t.pass()
+            t.deepEqual(role, directiveArgs.role)
+            return true
+          }
+        }
+      }
+    }
+  }
+  const info = {}
+
+  await field.resolve(root, args, context, info)
+})
+
+test('context.auth.hasRole is called when type is not specified, i.e. client type auth is used', async (t) => {
+  t.plan(3)
+  const directiveArgs = {
+    role: 'admin' // notice no type arg here
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      return new Promise((resolve, reject) => {
+        t.pass()
+        return resolve()
+      })
+    }
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {
+    auth: {
+      getToken: () => {
+        return {
+          hasRole: (role) => {
+            t.pass()
+            t.deepEqual(role, directiveArgs.role)
+            return true
+          }
+        }
+      }
+    }
+  }
+  const info = {}
+
+  await field.resolve(root, args, context, info)
+})
+
+test('field.resolve will throw an error when type is not one of [client, realm]', async (t) => {
+  const directiveArgs = {
+    role: 'admin',
+    type: 'some random type'
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      return new Promise((resolve, reject) => {
+        t.fail('the original resolver should never be called when an auth error is thrown')
+        return reject(new Error('the original resolver should never be called when an auth error is thrown'))
+      })
+    }
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {}
+  const info = {}
+
+  await t.throws(async () => {
+    await field.resolve(root, args, context, info)
+  }, 'type argument in hasRole directive must be one of client,realm')
+})
+
+test('if context.auth.getToken.hasRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
+  const directiveArgs = {
+    role: 'admin',
+    type: 'client'
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      return new Promise((resolve, reject) => {
+        t.fail('the original resolver should never be called when an auth error is thrown')
+        return reject(new Error('the original resolver should never be called when an auth error is thrown'))
+      })
+    },
+    name: 'test'
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {
+    auth: {
+      getToken: () => {
+        return {
+          hasRole: (role) => {
+            t.deepEqual(role, directiveArgs.role)
+            return false
+          }
+        }
+      }
+    }
+  }
+  const info = {}
+
+  await t.throws(async () => {
+    await field.resolve(root, args, context, info)
+  }, `logged in user does not have sufficient permissions for ${field.name}: missing role ${directiveArgs.role}`)
+})
+
+test('if context.auth.getToken.hasRealmRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
+  const directiveArgs = {
+    role: 'admin',
+    type: 'realm'
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      return new Promise((resolve, reject) => {
+        t.fail('the original resolver should never be called when an auth error is thrown')
+        return reject(new Error('the original resolver should never be called when an auth error is thrown'))
+      })
+    },
+    name: 'test'
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {
+    auth: {
+      getToken: () => {
+        return {
+          hasRealmRole: (role) => {
+            t.deepEqual(role, directiveArgs.role)
+            return false
+          }
+        }
+      }
+    }
+  }
+  const info = {}
+
+  await t.throws(async () => {
+    await field.resolve(root, args, context, info)
+  }, `logged in user does not have sufficient permissions for ${field.name}: missing role ${directiveArgs.role}`)
+})


### PR DESCRIPTION
## Motivation

This PR adds some basic unit tests to cover the tricky logic in the hasRole implementation for keycloak. There should be integration tests for the overall functionality, but this should at least guarantee that the logic within that function is solid and protects us from accidentally breaking it.

Related ticket: https://issues.jboss.org/browse/AEROGEAR-7841

