### PR TITLE
feat: support array of roles in keycloak hasRole

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4547,6 +4547,11 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -5003,6 +5008,21 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "isemail": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
+      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
+      "requires": {
+        "punycode": "2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5059,6 +5079,16 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
+    },
+    "joi": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
+      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
+      "requires": {
+        "hoek": "5.0.4",
+        "isemail": "3.1.3",
+        "topo": "3.0.0"
+      }
     },
     "js-beautify": {
       "version": "1.7.5",
@@ -10131,6 +10161,14 @@
       "requires": {
         "is-number": "3.0.0",
         "repeat-string": "1.6.1"
+      }
+    },
+    "topo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.4"
       }
     },
     "toposort-class": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "prom-client": "^11.1.1",
     "sequelize": "^4.38.0",
     "sequelize-cli": "^4.0.0",
-    "subscriptions-transport-ws": "^0.9.11"
+    "subscriptions-transport-ws": "^0.9.11",
+    "uuid": "^3.3.2"
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "graphql-tools": "^3.0.2",
     "graphql-validation-complexity": "^0.2.3",
     "handlebars": "^4.0.11",
+    "joi": "^13.6.0",
     "json-parse-safe": "^1.0.5",
     "keycloak-connect": "^4.2.1",
     "lodash": "^4.17.10",

--- a/server/lib/util/internalServerError.js
+++ b/server/lib/util/internalServerError.js
@@ -1,12 +1,12 @@
 const { ApolloError } = require('apollo-server-express')
 const uuid = require('uuid')
 
-const code = 'INTERNAL_SERVER_ERROR'
+const INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR'
 
 function newInternalServerError (context) {
   let errorId = (context && context.request) ? context.request.id : uuid.v4()
   const genericErrorMsg = `An internal server error occurred, please contact the server administrator and provide the following id: ${errorId}`
-  return new ApolloError(genericErrorMsg, code, { errorId })
+  return new ApolloError(genericErrorMsg, INTERNAL_SERVER_ERROR, { id: errorId })
 }
 
 module.exports = newInternalServerError

--- a/server/lib/util/internalServerError.js
+++ b/server/lib/util/internalServerError.js
@@ -1,0 +1,12 @@
+const { ApolloError } = require('apollo-server-express')
+const uuid = require('uuid')
+
+const code = 'INTERNAL_SERVER_ERROR'
+
+function newInternalServerError (context) {
+  let errorId = (context && context.request) ? context.request.id : uuid.v4()
+  const genericErrorMsg = `An internal server error occurred, please contact the server administrator and provide the following id: ${errorId}`
+  return new ApolloError(genericErrorMsg, code, { errorId })
+}
+
+module.exports = newInternalServerError

--- a/server/lib/util/internalServerError.test.js
+++ b/server/lib/util/internalServerError.test.js
@@ -1,0 +1,26 @@
+const { test } = require('ava')
+const newInternalServerError = require('./internalServerError')
+
+const INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR'
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+test('new internal server error returns a generic error with context.request.id', (t) => {
+  const context = {
+    request: {
+      id: '123'
+    }
+  }
+  const error = newInternalServerError(context)
+
+  t.deepEqual(error.id, context.request.id)
+  t.deepEqual(error.extensions.code, INTERNAL_SERVER_ERROR)
+  t.deepEqual(error.message, `An internal server error occurred, please contact the server administrator and provide the following id: ${context.request.id}`)
+})
+
+test('new internal server error returns a generic error with a uuid when no context is available', (t) => {
+  const error = newInternalServerError()
+
+  t.truthy(error.id)
+  t.regex(error.id, uuidRegex)
+  t.deepEqual(error.extensions.code, INTERNAL_SERVER_ERROR)
+})

--- a/server/security/services/keycloak/schemaDirectives/hasRole.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.js
@@ -21,13 +21,17 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
       let foundRole = null // this will be the role the user was successfully authorized on
 
       if (type === 'realm') {
-        foundRole = roles.find(token.hasRealmRole)
+        foundRole = roles.find((role) => {
+          return token.hasRealmRole(role)
+        })
       } else {
-        foundRole = roles.find(token.hasRole)
+        foundRole = roles.find((role) => {
+          return token.hasRole(role)
+        })
       }
 
       if (!foundRole) {
-        const AuthorizationErrorMessage = `logged in user does not have sufficient permissions for ${field.name}. Must have one of the following roles: [${roles}]`
+        const AuthorizationErrorMessage = `user is not authorized for field ${field.name} on parent ${info.parentType.name}. Must have one of the following roles: [${roles}]`
         log.error({ error: AuthorizationErrorMessage, details: token.content })
         throw new ForbiddenError(AuthorizationErrorMessage)
       }

--- a/server/security/services/keycloak/schemaDirectives/hasRole.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.js
@@ -1,6 +1,7 @@
 const { SchemaDirectiveVisitor } = require('graphql-tools')
 const { defaultFieldResolver } = require('graphql')
 const { ForbiddenError } = require('apollo-server-express')
+const newInternalServerError = require('../../../../lib/util/internalServerError')
 const Joi = require('joi')
 const { log } = require('../../../../lib/util/logger')
 
@@ -9,26 +10,22 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
     const { resolve = defaultFieldResolver } = field
     const { error, value } = this.validateArgs()
 
-    if (error) {
-      log.error(`Invalid hasRole directive found on ${field.name} field in schema`, error)
-      throw error
-    }
-
-    const { type, roles } = value
+    const { roles } = value
 
     field.resolve = async function (root, args, context, info) {
+      // must check for a validation error at runtime
+      // to ensure an appropriate message is sent back
+      if (error) {
+        log.error(`Invalid hasRole directive on field ${field.name} on parent ${info.parentType.name}`, error)
+        throw newInternalServerError(context)
+      }
+
       const token = context.auth.getToken()
       let foundRole = null // this will be the role the user was successfully authorized on
 
-      if (type === 'realm') {
-        foundRole = roles.find((role) => {
-          return token.hasRealmRole(role)
-        })
-      } else {
-        foundRole = roles.find((role) => {
-          return token.hasRole(role)
-        })
-      }
+      foundRole = roles.find((role) => {
+        return token.hasRole(role)
+      })
 
       if (!foundRole) {
         const AuthorizationErrorMessage = `user is not authorized for field ${field.name} on parent ${info.parentType.name}. Must have one of the following roles: [${roles}]`
@@ -43,13 +40,10 @@ class HasRoleDirective extends SchemaDirectiveVisitor {
   }
 
   validateArgs () {
-    const allowedTypes = ['client', 'realm']
-
     // joi is dope. Read the docs and discover the magic.
     // https://github.com/hapijs/joi/blob/master/API.md
     const argsSchema = Joi.object({
-      role: Joi.array().required().items(Joi.string()).single(),
-      type: Joi.string().valid(allowedTypes).default('client')
+      role: Joi.array().required().items(Joi.string()).single()
     })
 
     const result = argsSchema.validate(this.args)

--- a/server/security/services/keycloak/schemaDirectives/hasRole.test.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.test.js
@@ -206,7 +206,7 @@ test('if context.auth.getToken.hasRole() is false, then an error is returned and
         return reject(new Error('the original resolver should never be called when an auth error is thrown'))
       })
     },
-    name: 'test'
+    name: 'testField'
   }
 
   directive.visitFieldDefinition(field)
@@ -225,11 +225,15 @@ test('if context.auth.getToken.hasRole() is false, then an error is returned and
       }
     }
   }
-  const info = {}
+  const info = {
+    parentType: {
+      name: 'testParent'
+    }
+  }
 
   await t.throws(async () => {
     await field.resolve(root, args, context, info)
-  }, `logged in user does not have sufficient permissions for ${field.name}. Must have one of the following roles: [${directiveArgs.role}]`)
+  }, `user is not authorized for field ${field.name} on parent ${info.parentType.name}. Must have one of the following roles: [${directiveArgs.role}]`)
 })
 
 test('if context.auth.getToken.hasRealmRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
@@ -250,7 +254,7 @@ test('if context.auth.getToken.hasRealmRole() is false, then an error is returne
         return reject(new Error('the original resolver should never be called when an auth error is thrown'))
       })
     },
-    name: 'test'
+    name: 'testField'
   }
 
   directive.visitFieldDefinition(field)
@@ -269,9 +273,13 @@ test('if context.auth.getToken.hasRealmRole() is false, then an error is returne
       }
     }
   }
-  const info = {}
+  const info = {
+    parentType: {
+      name: 'testParent'
+    }
+  }
 
   await t.throws(async () => {
     await field.resolve(root, args, context, info)
-  }, `logged in user does not have sufficient permissions for ${field.name}. Must have one of the following roles: [${directiveArgs.role}]`)
+  }, `user is not authorized for field ${field.name} on parent ${info.parentType.name}. Must have one of the following roles: [${directiveArgs.role}]`)
 })

--- a/server/security/services/keycloak/schemaDirectives/hasRole.test.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.test.js
@@ -123,7 +123,47 @@ test('context.auth.hasRole is called when type is not specified, i.e. client typ
   await field.resolve(root, args, context, info)
 })
 
-test('field.resolve will throw an error when type is not one of [client, realm]', async (t) => {
+test('visitFieldDefinition accepts an array of roles', async (t) => {
+  t.plan(4)
+  const directiveArgs = {
+    role: ['foo', 'bar', 'baz'],
+    type: 'client'
+  }
+
+  const directive = new HasRoleDirective({
+    name: 'testHasRoleDirective',
+    args: directiveArgs
+  })
+
+  const field = {
+    resolve: (root, args, context, info) => {
+      t.pass()
+    }
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const context = {
+    auth: {
+      getToken: () => {
+        return {
+          hasRole: (role) => {
+            t.log(`checking has role ${role}`)
+            t.pass()
+            return (role === 'baz') // this makes sure it doesn't return true instantly
+          }
+        }
+      }
+    }
+  }
+  const info = {}
+
+  await field.resolve(root, args, context, info)
+})
+
+test('visitFieldDefinition will throw an error when type is not one of [client, realm]', async (t) => {
   const directiveArgs = {
     role: 'admin',
     type: 'some random type'
@@ -143,16 +183,9 @@ test('field.resolve will throw an error when type is not one of [client, realm]'
     }
   }
 
-  directive.visitFieldDefinition(field)
-
-  const root = {}
-  const args = {}
-  const context = {}
-  const info = {}
-
-  await t.throws(async () => {
-    await field.resolve(root, args, context, info)
-  }, 'type argument in hasRole directive must be one of client,realm')
+  t.throws(() => {
+    directive.visitFieldDefinition(field)
+  }, 'child "type" fails because ["type" must be one of [client, realm]]')
 })
 
 test('if context.auth.getToken.hasRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
@@ -196,7 +229,7 @@ test('if context.auth.getToken.hasRole() is false, then an error is returned and
 
   await t.throws(async () => {
     await field.resolve(root, args, context, info)
-  }, `logged in user does not have sufficient permissions for ${field.name}: missing role ${directiveArgs.role}`)
+  }, `logged in user does not have sufficient permissions for ${field.name}. Must have one of the following roles: [${directiveArgs.role}]`)
 })
 
 test('if context.auth.getToken.hasRealmRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
@@ -240,5 +273,5 @@ test('if context.auth.getToken.hasRealmRole() is false, then an error is returne
 
   await t.throws(async () => {
     await field.resolve(root, args, context, info)
-  }, `logged in user does not have sufficient permissions for ${field.name}: missing role ${directiveArgs.role}`)
+  }, `logged in user does not have sufficient permissions for ${field.name}. Must have one of the following roles: [${directiveArgs.role}]`)
 })

--- a/server/security/services/keycloak/schemaDirectives/hasRole.test.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.test.js
@@ -1,11 +1,10 @@
 const { test } = require('ava')
 const HasRoleDirective = require('./hasRole')
 
-test('context.auth.hasRole is called when type is client', async (t) => {
+test('context.auth.hasRole is called', async (t) => {
   t.plan(3)
   const directiveArgs = {
-    role: 'admin',
-    type: 'client'
+    role: 'admin'
   }
 
   const directive = new HasRoleDirective({
@@ -16,88 +15,6 @@ test('context.auth.hasRole is called when type is client', async (t) => {
   const field = {
     resolve: (root, args, context, info) => {
       t.pass()
-    }
-  }
-
-  directive.visitFieldDefinition(field)
-
-  const root = {}
-  const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
-          hasRole: (role) => {
-            t.pass()
-            t.deepEqual(role, directiveArgs.role)
-            return true
-          }
-        }
-      }
-    }
-  }
-  const info = {}
-
-  await field.resolve(root, args, context, info)
-})
-
-test('context.auth.hasRealmRole is called when type is realm', async (t) => {
-  t.plan(3)
-  const directiveArgs = {
-    role: 'admin',
-    type: 'realm'
-  }
-
-  const directive = new HasRoleDirective({
-    name: 'testHasRoleDirective',
-    args: directiveArgs
-  })
-
-  const field = {
-    resolve: (root, args, context, info) => {
-      t.pass()
-    }
-  }
-
-  directive.visitFieldDefinition(field)
-
-  const root = {}
-  const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
-          hasRealmRole: (role) => {
-            t.pass()
-            t.deepEqual(role, directiveArgs.role)
-            return true
-          }
-        }
-      }
-    }
-  }
-  const info = {}
-
-  await field.resolve(root, args, context, info)
-})
-
-test('context.auth.hasRole is called when type is not specified, i.e. client type auth is used', async (t) => {
-  t.plan(3)
-  const directiveArgs = {
-    role: 'admin' // notice no type arg here
-  }
-
-  const directive = new HasRoleDirective({
-    name: 'testHasRoleDirective',
-    args: directiveArgs
-  })
-
-  const field = {
-    resolve: (root, args, context, info) => {
-      return new Promise((resolve, reject) => {
-        t.pass()
-        return resolve()
-      })
     }
   }
 
@@ -126,8 +43,7 @@ test('context.auth.hasRole is called when type is not specified, i.e. client typ
 test('visitFieldDefinition accepts an array of roles', async (t) => {
   t.plan(4)
   const directiveArgs = {
-    role: ['foo', 'bar', 'baz'],
-    type: 'client'
+    role: ['foo', 'bar', 'baz']
   }
 
   const directive = new HasRoleDirective({
@@ -163,35 +79,9 @@ test('visitFieldDefinition accepts an array of roles', async (t) => {
   await field.resolve(root, args, context, info)
 })
 
-test('visitFieldDefinition will throw an error when type is not one of [client, realm]', async (t) => {
-  const directiveArgs = {
-    role: 'admin',
-    type: 'some random type'
-  }
-
-  const directive = new HasRoleDirective({
-    name: 'testHasRoleDirective',
-    args: directiveArgs
-  })
-
-  const field = {
-    resolve: (root, args, context, info) => {
-      return new Promise((resolve, reject) => {
-        t.fail('the original resolver should never be called when an auth error is thrown')
-        return reject(new Error('the original resolver should never be called when an auth error is thrown'))
-      })
-    }
-  }
-
-  t.throws(() => {
-    directive.visitFieldDefinition(field)
-  }, 'child "type" fails because ["type" must be one of [client, realm]]')
-})
-
 test('if context.auth.getToken.hasRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
   const directiveArgs = {
-    role: 'admin',
-    type: 'client'
+    role: 'admin'
   }
 
   const directive = new HasRoleDirective({
@@ -218,54 +108,6 @@ test('if context.auth.getToken.hasRole() is false, then an error is returned and
       getToken: () => {
         return {
           hasRole: (role) => {
-            t.deepEqual(role, directiveArgs.role)
-            return false
-          }
-        }
-      }
-    }
-  }
-  const info = {
-    parentType: {
-      name: 'testParent'
-    }
-  }
-
-  await t.throws(async () => {
-    await field.resolve(root, args, context, info)
-  }, `user is not authorized for field ${field.name} on parent ${info.parentType.name}. Must have one of the following roles: [${directiveArgs.role}]`)
-})
-
-test('if context.auth.getToken.hasRealmRole() is false, then an error is returned and the original resolver will not execute', async (t) => {
-  const directiveArgs = {
-    role: 'admin',
-    type: 'realm'
-  }
-
-  const directive = new HasRoleDirective({
-    name: 'testHasRoleDirective',
-    args: directiveArgs
-  })
-
-  const field = {
-    resolve: (root, args, context, info) => {
-      return new Promise((resolve, reject) => {
-        t.fail('the original resolver should never be called when an auth error is thrown')
-        return reject(new Error('the original resolver should never be called when an auth error is thrown'))
-      })
-    },
-    name: 'testField'
-  }
-
-  directive.visitFieldDefinition(field)
-
-  const root = {}
-  const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
-          hasRealmRole: (role) => {
             t.deepEqual(role, directiveArgs.role)
             return false
           }

--- a/server/server.js
+++ b/server/server.js
@@ -99,7 +99,7 @@ class DataSyncServer {
     log.info('Received schema change notification. Rebuilding it')
     let newSchema
     try {
-      newSchema = await buildSchema(this.models, this.pubsub)
+      newSchema = await buildSchema(this.models, this.pubsub, this.schemaDirectives)
     } catch (ex) {
       log.error('Error while reloading config')
       log.error(ex)


### PR DESCRIPTION
## Motivation

This PR adds the ability to specify an array of roles in the `hasRole` directive for keycloak. The following syntax is now supported:

```
@hasRole(role: ["editor", "admin", "reader"])
@hasRole(role: ["editor", "admin", "reader"], type: "client")
@hasRole(role: ["editor", "admin", "reader"], type: "realm")

@hasRole(role: "admin")
@hasRole(role: "admin", type: "client")
@hasRole(role: "admin", type: "realm")
```

## How

One of the main things I want to draw attention to is that I've introduced a new dependency called Joi. [Joi](https://npm.im/joi) is one of the most sophisticated validation libraries I've ever used.

You can see an example of how it's being used in the `validateArgs` function

```js
    const allowedTypes = ['client', 'realm']

    // joi is dope. Read the docs and discover the magic.
    // https://github.com/hapijs/joi/blob/master/API.md
    const argsSchema = Joi.object({
      role: Joi.array().required().items(Joi.string()).single(),
      type: Joi.string().valid(allowedTypes).default('client')
    })

    const result = argsSchema.validate(this.args)
```

If you're interested, here's quick summary of what the schema is doing:

* the input must be an object (`Joi.object`)
* The object must have the keys `role` and `type`. Any additional keys will cause a validation error. This means `@hasRole(role: "admin", type: "client", foo: "bar")` will cause an error because `foo` is not allowed.
* the role field is 
	* an array (`Joi.array()`), 
	* it is required (`.required()`) 
	* it must contain only strings (`.items(Joi.string())`)
	* if only a single string is given instead of an array, then it will be converted into an array with that string as the only element (`single()`). i.e. `{role: "admin"}` automatically becomes `{role: ["admin"]}`
* the type field
	* is a string
	* only the allowedTypes are valid (`.valid(allowedTypes)`)
	* if nothing is passed, the default value is `client`

Think about how much code you'd need to write to create that behaviour. This only scratches the surface in terms of what's possible with this library.

To learn more, check out the API docs: https://github.com/hapijs/joi/blob/master/API.md

I've been meaning to bring it in for some time but hadn't gotten around to it yet. There are plenty of other parts of the server where something like this would come in very handy. (validating resolvermappings, datasources, subscriptions etc at startup/reload time)

## Verification Steps

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modify the appearance/output of something presented to the users. 
 

