### PR TITLE
Include examples in dockerimage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ CONTRIBUTING.md
 Jenkinsfile
 LICENSE
 README.md
-examples
 *.png
 nodemon.json
 k8s_templates


### PR DESCRIPTION
## Motivation

To mount examples into playground (temporarily).
We need that to have this files in the docker image so we can populate example queries.