### PR TITLE
Bugfix: Server drops security when schema reloaded

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -8,8 +8,8 @@ const SecurityService = require('./security/SecurityService')
 
 // middlewares
 const { log } = require('./lib/util/logger')
-const expressPino = require('express-pino-logger')({logger: log})
-const {getMetrics, responseLoggingMetric} = require('./metrics')
+const expressPino = require('express-pino-logger')({ logger: log })
+const { getMetrics, responseLoggingMetric } = require('./metrics')
 
 // schema
 const buildSchema = require('./buildSchema')
@@ -70,7 +70,7 @@ class DataSyncServer {
 
     // Initialize an express app, apply the apollo middleware, and mount the app to the http server
     this.app = newExpressApp(this.expressAppOptions, this.expressAppMiddlewares, this.securityService)
-    this.apolloServer = newApolloServer(this.app, this.schema, this.server, tracing, playgroundConfig, graphqlEndpoint, this.securityService, this.serverSecurity)
+    this.apolloServer = newApolloServer(this.app, this.schema, this.server, tracing, playgroundConfig, this.expressAppOptions.graphqlEndpoint, this.securityService, this.serverSecurity)
     this.server.on('request', this.app)
 
     function startListening (port) {
@@ -112,8 +112,8 @@ class DataSyncServer {
       this.server.removeListener('request', this.app)
       // reinitialize the server objects
       this.schema = newSchema.schema
-      this.app = newExpressApp(this.expressAppOptions, this.expressAppMiddlewares)
-      this.apolloServer = newApolloServer(this.app, this.schema, this.server, this.config.graphQLConfig.tracing, this.config.playgroundConfig, this.config.graphQLConfig.graphqlEndpoint, this.securityService, this.serverSecurity)
+      this.app = newExpressApp(this.expressAppOptions, this.expressAppMiddlewares, this.securityService)
+      this.apolloServer = newApolloServer(this.app, this.schema, this.server, this.config.graphQLConfig.tracing, this.config.playgroundConfig, this.expressAppOptions.graphqlEndpoint, this.securityService, this.serverSecurity)
       this.server.on('request', this.app)
 
       try {


### PR DESCRIPTION
## Motivation
Server was dropping security when schema was reloaded.

## What
Some parameters are not passed in `server/server.js` in `newApolloServer()` and `newExpressApp` while schema is being reloaded.

## How
Pass the missing parameters.

## Verification Steps
1. Start server with Keycloak enabled
2. Call to `/graphql` endpoint invokes Keycloak login
3. Do schema update (using for example `data-sync-ui`)

Expected: Call to `/graphql` endpoint invokes Keycloak login (when not logged in)

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task


