### PR TITLE
fix: role name in package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "release:validate": "./scripts/validateRelease.sh",
     "db:init": "FORCE_DROP=true node ./scripts/sync_models",
     "db:init:memeo:inmem": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-inmem.js",
-    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec sync_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
+    "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec sync_postgres_memeo_1 psql -U postgresql -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
     "db:shell": "docker exec -it sync_postgres_1 psql -U postgresql -d aerogear_data_sync_db",
     "db:shell:memeo": "docker exec -it sync_postgres_memeo_1 psql -U postgresql -d memeolist_db"
   },


### PR DESCRIPTION
## Why
`npm run db:init:memeo:postgres` ➡️  `postgres_memeo_1  | FATAL:  role "postgres" does not exist`
 

