### PR TITLE
Added script to initialize a local keycloak instance

### DIFF
--- a/keycloak/index.js
+++ b/keycloak/index.js
@@ -1,0 +1,44 @@
+/* eslint no-console: 0 */
+const keycloakInit = require('./keycloakInit')
+const os = require('os')
+
+function getIpAddress () {
+  var ifaces = os.networkInterfaces()
+
+  for (var ifname of Object.keys(ifaces)) {
+    for (var iface of ifaces[ifname]) {
+      if (iface.family !== 'IPv4' || iface.internal !== false) {
+        // skip over internal (i.e. 127.0.0.1) and non-ipv4 addresses
+        continue
+      }
+
+      return iface.address
+    }
+  }
+}
+
+async function init () {
+  await keycloakInit.resetKeycloakConfiguration('http://127.0.0.1:8080/auth')
+  await keycloakInit.prepareKeycloak('http://127.0.0.1:8080/auth')
+
+  const keycloakUrl = `http://${getIpAddress()}.nip.io:8080/auth`
+  var json = `{ "realm": "Memeolist", "auth-server-url": "${keycloakUrl}", "ssl-required": "external", "resource": "sync-server", "public-client": true }`
+
+  var fs = require('fs')
+  fs.writeFile('./keycloak/keycloak-local.json', json, function (err) {
+    if (err) {
+      return console.log('Error creating keycloak-local.json file', err)
+    }
+
+    console.log(`A local keycloak as been configured, you can access such instance at ${keycloakUrl}`)
+    console.log('username/password: admin/admin')
+    console.log('The following users have been created: (username/password)\n')
+    console.log('   * voter/voter')
+    console.log('   * voter2/voter2')
+
+    console.log('\nTo use this keycloak instance with the syncserver, please use the following command:\n')
+    console.log('KEYCLOAK_CONFIG_FILE=./keycloak/keycloak-local.json npm run dev')
+  })
+}
+
+init()

--- a/keycloak/keycloakInit.js
+++ b/keycloak/keycloakInit.js
@@ -1,0 +1,149 @@
+const axios = require('axios')
+const realmToImport = require('./realm-export.json')
+
+const config = {
+  appRealmName: 'Memeolist',
+  adminRealmName: 'master',
+  resource: 'admin-cli',
+  username: 'admin',
+  password: 'admin',
+  token: null,
+  authServerUrl: null
+}
+
+const usersConfiguration = [
+  { name: 'test-admin', realmRoles: ['admin'], clientId: 'sync-server', clientRoleName: 'admin' },
+  { name: 'voter', realmRoles: ['admin', 'voter'], clientId: 'sync-server', clientRoleName: 'voter', email: 'voter@redhat.com', firstName: 'voter', lastName: 'voter' },
+  { name: 'voter2', realmRoles: ['admin', 'voter'], clientId: 'sync-server', clientRoleName: 'voter', email: 'voter2@redhat.com', firstName: 'voter2', lastName: 'voter2' }
+]
+
+async function getRealmRoles () {
+  const res = await axios({
+    method: 'GET',
+    url: `${config.authServerUrl}/admin/realms/${config.appRealmName}/roles`,
+    headers: {'Authorization': config.token}
+  }).catch((err) => { throw Error(err) })
+
+  return res.data
+}
+
+async function getClients () {
+  const res = await axios({
+    method: 'GET',
+    url: `${config.authServerUrl}/admin/realms/${config.appRealmName}/clients`,
+    headers: {'Authorization': config.token}
+  }).catch((err) => { throw Error(err) })
+
+  return res.data
+}
+
+async function getClientRoles (client) {
+  const res = await axios({
+    method: 'GET',
+    url: `${config.authServerUrl}/admin/realms/${config.appRealmName}/clients/${client.id}/roles`,
+    headers: {'Authorization': config.token}
+  }).catch((err) => { throw Error(err) })
+  return res.data
+}
+
+async function assignRealmRoleToUser (userIdUrl, role) {
+  const res = await axios({
+    method: 'POST',
+    url: `${userIdUrl}/role-mappings/realm`,
+    data: [role],
+    headers: {'Authorization': config.token, 'Content-Type': 'application/json'}
+  }).catch((err) => { throw Error(err) })
+
+  return res.data
+}
+
+async function assignClientRoleToUser (userIdUrl, client, role) {
+  const res = await axios({
+    method: 'POST',
+    url: `${userIdUrl}/role-mappings/clients/${client.id}`,
+    data: [role],
+    headers: {'Authorization': config.token, 'Content-Type': 'application/json'}
+  }).catch((err) => { throw Error(err) })
+  return res.data
+}
+
+/// //////////////////////////////////////////////
+
+async function createUser (user) {
+  const res = await axios({
+    method: 'post',
+    url: `${config.authServerUrl}/admin/realms/${config.appRealmName}/users`,
+    data: {
+      'username': user.name,
+      'credentials': [{'type': 'password', 'value': user.name, 'temporary': false}],
+      'email': user.email,
+      'enabled': true,
+      'firstName': user.firstName,
+      'lastName': user.lastName
+    },
+    headers: {'Authorization': config.token, 'Content-Type': 'application/json'}
+  }).catch((err) => { throw Error(err) })
+
+  return res.headers.location
+}
+
+async function authenticateKeycloak () {
+  const res = await axios({
+    method: 'POST',
+    url: `${config.authServerUrl}/realms/${config.adminRealmName}/protocol/openid-connect/token`,
+    data: `client_id=${config.resource}&username=${config.username}&password=${config.password}&grant_type=password`
+  }).catch((err) => { throw Error(err) })
+  return `Bearer ${res.data['access_token']}`
+}
+
+async function importRealm () {
+  await axios({
+    method: 'POST',
+    url: `${config.authServerUrl}/admin/realms`,
+    data: realmToImport,
+    headers: {'Authorization': config.token, 'Content-Type': 'application/json'}
+  }).catch((err) => { throw Error(err) })
+}
+
+async function prepareKeycloak (authServerUrl) {
+  config.authServerUrl = authServerUrl
+  config.token = await authenticateKeycloak()
+  await importRealm()
+  const realmRoles = await getRealmRoles()
+  const clients = await getClients()
+
+  usersConfiguration.forEach(async user => {
+    // Create a new user
+    const userIdUrl = await createUser(user)
+    // Assign realm role to user
+    if (user.realmRoles) {
+      for (var roleName of user.realmRoles) {
+        const selectedRealmRole = realmRoles.find(role => role.name === roleName)
+        await assignRealmRoleToUser(userIdUrl, selectedRealmRole)
+      }
+    }
+    // Assign client role to user
+    if (user.clientId && user.clientRoleName) {
+      const selectedClient = clients.find(client => client.clientId === user.clientId)
+      const clientRoles = await getClientRoles(selectedClient)
+      const selectedClientRole = clientRoles.find(clientRole => clientRole.name === user.clientRoleName)
+      // console.log(selectedClient, clientRoles)
+      await assignClientRoleToUser(userIdUrl, selectedClient, selectedClientRole)
+    }
+  })
+}
+
+async function resetKeycloakConfiguration (authServerUrl) {
+  config.authServerUrl = authServerUrl
+  config.token = await authenticateKeycloak()
+  await axios({
+    method: 'DELETE',
+    url: `${config.authServerUrl}/admin/realms/${config.appRealmName}`,
+    headers: {'Authorization': config.token}
+  }).catch((err) => { /* return throw Error(err) */ }) // eslint-disable-line handle-callback-err
+}
+
+module.exports = {
+  prepareKeycloak,
+  resetKeycloakConfiguration
+}

--- a/keycloak/realm-export.json
+++ b/keycloak/realm-export.json
@@ -294,7 +294,24 @@
       ],
       "security-admin-console": [],
       "admin-cli": [],
-      "sync-server": [],
+      "sync-server": [
+        {
+          "id": "6ee57320-6ed9-4d51-addf-fb3de0e69546",
+          "name": "voter",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "66dfe449-ee2e-42e5-afd6-a59f5e005538"
+        },
+        {
+          "id": "4199885c-25d2-4d2e-b542-d3f9463bdf89",
+          "name": "admin",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "66dfe449-ee2e-42e5-afd6-a59f5e005538"
+        }
+      ],
       "android-app": [],
       "broker": [
         {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "db:init:memeo:inmem": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-inmem.js",
     "db:init:memeo:postgres": "FORCE_DROP=true node ./scripts/sync_models && sequelize db:seed --seed memeolist-example-postgres.js && docker exec sync_postgres_memeo_1 psql -U postgres -d memeolist_db -f /tmp/examples/memeolist.tables.sql",
     "db:shell": "docker exec -it sync_postgres_1 psql -U postgresql -d aerogear_data_sync_db",
-    "db:shell:memeo": "docker exec -it sync_postgres_memeo_1 psql -U postgresql -d memeolist_db"
+    "db:shell:memeo": "docker exec -it sync_postgres_memeo_1 psql -U postgresql -d memeolist_db",
+    "keycloak:init:memeo": "node ./keycloak"
   },
   "devDependencies": {
     "apollo-cache-inmemory": "^1.3.0-beta.6",

--- a/scripts/keycloak_init.js
+++ b/scripts/keycloak_init.js
@@ -1,0 +1,6 @@
+
+if (require.main === module) {
+  require('../keycloak').init()
+} else {
+  throw Error('This file should not be imported. Ever.')
+}


### PR DESCRIPTION
## Motivation
There were scripts to initialize the database to be used with the memeolist app, but no script was provided to configure a local keycloak.

## What
Added a new script to configure the local keycloak instance to be used with the memeolist app (heavily based on @psturc scripts)

## How
A new command is provided:

```bash
$ npm run keycloak:init:memeo

A local keycloak as been configured, you can access such instance at http://192.168.1.187.nip.io:8080/auth
username/password: admin/admin
The following users have been created: (username/password)

   * voter/voter
   * voter2/voter2

To use this keycloak instance with the syncserver, please use the following command:

KEYCLOAK_CONFIG_FILE=./keycloak/keycloak-local.json npm run dev
```

## Verification Steps

1. After running the `docker-compose` command as documented in the sync server docs, run the `npm run keycloak:init:memeo` command
2. run the sync server with `KEYCLOAK_CONFIG_FILE=./keycloak/keycloak-local.json npm run dev`
3. Inside the memeolist app, edit the `mobile-services.json` file to point to the provided keycloak URL
4. Run the memeolist and ensure that it works

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 


