### PR TITLE
AEROGEAR-8094 - Sync server to extract user info from Keycloak token …

### DIFF
--- a/server/lib/util/logger.js
+++ b/server/lib/util/logger.js
@@ -42,7 +42,9 @@ function auditLog (success, context, info, parent, args, msg) {
         parent: parent,
         arguments: args,
         dataSourceType: info.dataSourceType || '',
-        clientInfo: context ? context.clientInfo : undefined
+        clientInfo: context ? context.clientInfo : undefined,
+        authenticated: !!(context && context.auth && context.auth.isAuthenticated()),
+        userInfo: (context && context.auth) ? context.auth.getTokenContent() : undefined
       }
     })
   }

--- a/server/security/services/keycloak/AuthContextProvider.js
+++ b/server/security/services/keycloak/AuthContextProvider.js
@@ -9,6 +9,18 @@ class KeycloakAuthContextProvider {
     }
     return null
   }
+
+  isAuthenticated () {
+    return this.getToken() !== null
+  }
+
+  getTokenContent () {
+    return this.isAuthenticated() ? this.getToken().content : null
+  }
+
+  hasRole (role) {
+    return this.isAuthenticated() && this.getToken().hasRole(role)
+  }
 }
 
 module.exports = KeycloakAuthContextProvider

--- a/server/security/services/keycloak/AuthContextProvider.js
+++ b/server/security/services/keycloak/AuthContextProvider.js
@@ -1,17 +1,16 @@
 class KeycloakAuthContextProvider {
   constructor (request) {
     this.request = request
+    this.accessToken = (request && request.kauth && request.kauth.grant) ? request.kauth.grant.access_token : undefined
+    this.authenticated = !!(this.accessToken)
   }
 
   getToken () {
-    if (this.request.kauth && this.request.kauth.grant && this.request.kauth.grant.access_token) {
-      return this.request.kauth.grant.access_token
-    }
-    return null
+    return this.accessToken
   }
 
   isAuthenticated () {
-    return this.getToken() !== null
+    return this.authenticated
   }
 
   getTokenContent () {

--- a/server/security/services/keycloak/AuthContextProvider.test.js
+++ b/server/security/services/keycloak/AuthContextProvider.test.js
@@ -25,3 +25,98 @@ test('provider.getToken() returns null when request.kauth is not available', (t)
   const provider = new AuthContextProvider(request)
   t.falsy(provider.getToken())
 })
+
+test('provider.isAuthenticated() returns true when there is a token', (t) => {
+  const token = {
+    someField: 'foo'
+  }
+  const request = {
+    kauth: {
+      grant: {
+        access_token: token
+      }
+    }
+  }
+
+  const provider = new AuthContextProvider(request)
+  t.true(provider.isAuthenticated())
+})
+
+test('provider.isAuthenticated() returns false when there is no token', (t) => {
+  const request = {}
+
+  const provider = new AuthContextProvider(request)
+  t.false(provider.isAuthenticated())
+})
+
+test('provider.getTokenContent() returns the content when there is a token', (t) => {
+  const token = {
+    someField: 'foo',
+    content: {'a': 'b'}
+  }
+  const request = {
+    kauth: {
+      grant: {
+        access_token: token
+      }
+    }
+  }
+
+  const provider = new AuthContextProvider(request)
+  t.truthy(provider.getTokenContent())
+  t.deepEqual(provider.getTokenContent(), {'a': 'b'})
+})
+
+test('provider.getTokenContent() returns null when there is no token', (t) => {
+  const request = {}
+
+  const provider = new AuthContextProvider(request)
+  t.falsy(provider.getTokenContent())
+})
+
+test('provider.hasRole() returns true when there is a token and the token has the role', (t) => {
+  const token = {
+    someField: 'foo',
+    content: {'a': 'b'},
+    hasRole: (role) => {
+      return role === 'admin'
+    }
+  }
+  const request = {
+    kauth: {
+      grant: {
+        access_token: token
+      }
+    }
+  }
+
+  const provider = new AuthContextProvider(request)
+  t.true(provider.hasRole('admin'))
+})
+
+test('provider.hasRole() returns false when there is a token but the token dont have the role', (t) => {
+  const token = {
+    someField: 'foo',
+    content: {'a': 'b'},
+    hasRole: (role) => {
+      return role === 'admin'
+    }
+  }
+  const request = {
+    kauth: {
+      grant: {
+        access_token: token
+      }
+    }
+  }
+
+  const provider = new AuthContextProvider(request)
+  t.false(provider.hasRole('super-uber-admin'))
+})
+
+test('provider.hasRole() returns false when there is no token', (t) => {
+  const request = {}
+
+  const provider = new AuthContextProvider(request)
+  t.false(provider.hasRole('foo'))
+})

--- a/server/security/services/keycloak/schemaDirectives/hasRole.test.js
+++ b/server/security/services/keycloak/schemaDirectives/hasRole.test.js
@@ -1,5 +1,6 @@
 const { test } = require('ava')
 const HasRoleDirective = require('./hasRole')
+const KeycloakAuthContextProvider = require('../AuthContextProvider')
 
 test('context.auth.hasRole is called', async (t) => {
   t.plan(3)
@@ -23,10 +24,10 @@ test('context.auth.hasRole is called', async (t) => {
 
   const root = {}
   const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
+  const req = {
+    kauth: {
+      grant: {
+        access_token: {
           hasRole: (role) => {
             t.pass()
             t.deepEqual(role, directiveArgs.role)
@@ -36,6 +37,11 @@ test('context.auth.hasRole is called', async (t) => {
       }
     }
   }
+  const context = {
+    request: req,
+    auth: new KeycloakAuthContextProvider(req)
+  }
+
   const info = {
     parentType: {
       name: 'testParent'
@@ -67,10 +73,10 @@ test('visitFieldDefinition accepts an array of roles', async (t) => {
 
   const root = {}
   const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
+  const req = {
+    kauth: {
+      grant: {
+        access_token: {
           hasRole: (role) => {
             t.log(`checking has role ${role}`)
             t.pass()
@@ -80,6 +86,11 @@ test('visitFieldDefinition accepts an array of roles', async (t) => {
       }
     }
   }
+  const context = {
+    request: req,
+    auth: new KeycloakAuthContextProvider(req)
+  }
+
   const info = {
     parentType: {
       name: 'testParent'
@@ -113,10 +124,10 @@ test('if context.auth.getToken.hasRole() is false, then an error is returned and
 
   const root = {}
   const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
+  const req = {
+    kauth: {
+      grant: {
+        access_token: {
           hasRole: (role) => {
             t.deepEqual(role, directiveArgs.role)
             return false
@@ -125,6 +136,11 @@ test('if context.auth.getToken.hasRole() is false, then an error is returned and
       }
     }
   }
+  const context = {
+    request: req,
+    auth: new KeycloakAuthContextProvider(req)
+  }
+
   const info = {
     parentType: {
       name: 'testParent'
@@ -163,21 +179,24 @@ test('if hasRole arguments are invalid, visitSchemaDirective does not throw, but
 
   const root = {}
   const args = {}
-  const context = {
-    auth: {
-      getToken: () => {
-        return {
+  const req = {
+    id: '123',
+    kauth: {
+      grant: {
+        access_token: {
           hasRole: (role) => {
             t.deepEqual(role, directiveArgs.role)
             return false
           }
         }
       }
-    },
-    request: {
-      id: '123'
     }
   }
+  const context = {
+    request: req,
+    auth: new KeycloakAuthContextProvider(req)
+  }
+
   const info = {
     parentType: {
       name: 'testParent'


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AEROGEAR-8094

Things done:
* If user is authenticated, print "authenticated:true" in the audit logs as well as the token details
* If user is not authenticated (also if auth is not enabled on sync server), print "authenticated:false"
* Created some abstraction for called token internals like `token.hasRole()`, `token.content`. So, instead of getting the token and calling 'token.hasRole()', leave it to 'context.auth.hasRole()'. This could be improved further by creating an interface like `AuthContextProvider` which could be implemented for different auth providers like `KeycloakAuthContextProvider`, etc.

Sample output with no auth enabled:
```
{
  tag: "AUDIT"
  audit: {
    "msg": "",
    "requestId": 1,
    "operationType": "query",
    "parentTypeName": "Query",
    "path": "allMemes",
    "success": true,
    "arguments": {},
    "dataSourceType": "InMemory",
    "authenticated": false
  }
}
```

Sample output with auth:
```
{
  tag: "AUDIT"
  audit: {
    "msg": "",
    "requestId": 19,
    "operationType": "query",
    "parentTypeName": "Query",
    "path": "allMemes",
    "success": true,
    "arguments": {},
    "dataSourceType": "InMemory",
    "authenticated": true,
    "userInfo": {
      "jti": "33981caa-f8a3-4527-9cfa-8d8d32540b72",
      "exp": 1541665472,
      "nbf": 0,
      "iat": 1541665172,
      "iss": "http://localhost:8080/auth/realms/Memeolist",
      "aud": "sync-server",
      "sub": "465879a1-30e8-446a-afd6-d8e99394b0ce",
      "typ": "Bearer",
      "azp": "sync-server",
      "auth_time": 1541664711,
      "session_state": "0c99d581-4f07-4873-8e90-7710026e396c",
      "acr": "0",
      "allowed-origins": [
        "localhost:8000"
      ],
      "realm_access": {
        "roles": [
          "admin",
          "uma_authorization",
          "voter"
        ]
      },
      "resource_access": {
        "account": {
          "roles": [
            "manage-account",
            "manage-account-links",
            "view-profile"
          ]
        }
      },
      "name": "Ali Ok",
      "preferred_username": "test",
      "given_name": "Ali",
      "family_name": "Ok",
      "email": "aliok@example.com"
    }
  }
}
```

How to verify:
1. Start sync server with memeo but no Keycloak and execute a query. Check the audit logs
2. Start sync server with memeo and Keycloak and execute a query. Check the audit logs.
```
cd keycloak 
docker-compose
go to localhost:8000
--> import realm-export.json into Keycloak
--> create a user with role voter or admin
--> reset pass for the user
--> change url in keycloak.json to http://localhost:8080/auth
npm run db:init:memeo:inmem
npm run dev:keymemeo
--> go to localhost:8080/graphql
--> login
--> go to localhost:8080/token and copy the token
--> paste it in the headers section in localhost:8080/graphql
--> execute a query
```
